### PR TITLE
This commit fully implements the Groq provider by leveraging the exis…

### DIFF
--- a/Sources/Tachikoma/Providers/Groq/GroqProvider.swift
+++ b/Sources/Tachikoma/Providers/Groq/GroqProvider.swift
@@ -36,10 +36,24 @@ public final class GroqProvider: ModelProvider {
     }
 
     public func generateText(request: ProviderRequest) async throws -> ProviderResponse {
-        throw TachikomaError.unsupportedOperation("Groq provider not yet implemented")
+        // Groq uses OpenAI-compatible API format - delegate to shared implementation
+        return try await OpenAICompatibleHelper.generateText(
+            request: request,
+            modelId: self.modelId,
+            baseURL: self.baseURL!,
+            apiKey: self.apiKey!,
+            providerName: "Groq"
+        )
     }
 
     public func streamText(request: ProviderRequest) async throws -> AsyncThrowingStream<TextStreamDelta, Error> {
-        throw TachikomaError.unsupportedOperation("Groq streaming not yet implemented")
+        // Groq uses OpenAI-compatible API format - delegate to shared implementation
+        return try await OpenAICompatibleHelper.streamText(
+            request: request,
+            modelId: self.modelId,
+            baseURL: self.baseURL!,
+            apiKey: self.apiKey!,
+            providerName: "Groq"
+        )
     }
 }


### PR DESCRIPTION
…ting OpenAICompatibleHelper.

The 'generateText' and 'streamText' methods in GroqProvider.swift now delegate to the helper, consistent with other OpenAI-compatible providers like Grok and OpenAI.

This enables support for Groq's fast inference API.