### PR TITLE
Fix Commander dependency to use remote URL instead of local path

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
             targets: ["TachikomaConfigCLI"]),
     ],
     dependencies: [
-        .package(path: "../Commander"),
+        .package(url: "https://github.com/steipete/Commander.git", from: "0.2.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.4"),
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.10.2"),
         .package(url: "https://github.com/apple/swift-configuration", from: "1.0.0"),


### PR DESCRIPTION
## Summary

- Changes Commander dependency from local path (`../Commander`) to remote URL
- Enables Tachikoma to be used as a SwiftPM dependency in other projects

## Problem

The current `Package.swift` uses a local path dependency:

```swift
.package(path: "../Commander")
```

This works for local development but prevents other projects from using Tachikoma as a dependency, since SwiftPM cannot resolve `../Commander` when pulling from a remote repository.

## Solution

Use the published Commander package:

```swift
.package(url: "https://github.com/steipete/Commander.git", from: "0.2.1")
```

## Testing

- [x] `swift package resolve` succeeds
- [x] `swift build --target Tachikoma` succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)