### PR TITLE
fix(mcp): support current tool content resources

### DIFF
--- a/Sources/TachikomaMCP/Bridge/MCPToolAdapter.swift
+++ b/Sources/TachikomaMCP/Bridge/MCPToolAdapter.swift
@@ -259,18 +259,37 @@ public enum MCPToolAdapter {
                 "mimeType": AnyAgentToolValue(string: mimeType),
                 "data": AnyAgentToolValue(string: data),
             ])
-        case let .resource(uri, mimeType, text):
+        case let .resource(resource, _, _):
             var resourceDict: [String: AnyAgentToolValue] = [
                 "type": AnyAgentToolValue(string: "resource"),
-                "uri": AnyAgentToolValue(string: uri),
-                "mimeType": AnyAgentToolValue(string: mimeType),
+                "uri": AnyAgentToolValue(string: resource.uri),
             ]
-            if let text {
+            if let mimeType = resource.mimeType {
+                resourceDict["mimeType"] = AnyAgentToolValue(string: mimeType)
+            } else {
+                resourceDict["mimeType"] = AnyAgentToolValue(null: ())
+            }
+            if let text = resource.text {
                 resourceDict["text"] = AnyAgentToolValue(string: text)
             } else {
                 resourceDict["text"] = AnyAgentToolValue(null: ())
             }
+            if let blob = resource.blob {
+                resourceDict["blob"] = AnyAgentToolValue(string: blob)
+            } else {
+                resourceDict["blob"] = AnyAgentToolValue(null: ())
+            }
             return AnyAgentToolValue(object: resourceDict)
+        case let .resourceLink(uri, name, title, description, mimeType, _):
+            var resourceLinkDict: [String: AnyAgentToolValue] = [
+                "type": AnyAgentToolValue(string: "resourceLink"),
+                "uri": AnyAgentToolValue(string: uri),
+                "name": AnyAgentToolValue(string: name),
+            ]
+            resourceLinkDict["title"] = title.map { AnyAgentToolValue(string: $0) } ?? AnyAgentToolValue(null: ())
+            resourceLinkDict["description"] = description.map { AnyAgentToolValue(string: $0) } ?? AnyAgentToolValue(null: ())
+            resourceLinkDict["mimeType"] = mimeType.map { AnyAgentToolValue(string: $0) } ?? AnyAgentToolValue(null: ())
+            return AnyAgentToolValue(object: resourceLinkDict)
         case let .audio(data, mimeType):
             return AnyAgentToolValue(object: [
                 "type": AnyAgentToolValue(string: "audio"),

--- a/Sources/TachikomaMCP/Bridge/MCPToolProvider.swift
+++ b/Sources/TachikomaMCP/Bridge/MCPToolProvider.swift
@@ -193,18 +193,37 @@ public final class MCPToolProvider: DynamicToolProvider {
                 "mimeType": AnyAgentToolValue(string: mimeType),
                 "data": AnyAgentToolValue(string: data),
             ])
-        case let .resource(uri, mimeType, text):
+        case let .resource(resource, _, _):
             var resourceDict: [String: AnyAgentToolValue] = [
                 "type": AnyAgentToolValue(string: "resource"),
-                "uri": AnyAgentToolValue(string: uri),
-                "mimeType": AnyAgentToolValue(string: mimeType),
+                "uri": AnyAgentToolValue(string: resource.uri),
             ]
-            if let text {
+            if let mimeType = resource.mimeType {
+                resourceDict["mimeType"] = AnyAgentToolValue(string: mimeType)
+            } else {
+                resourceDict["mimeType"] = AnyAgentToolValue(null: ())
+            }
+            if let text = resource.text {
                 resourceDict["text"] = AnyAgentToolValue(string: text)
             } else {
                 resourceDict["text"] = AnyAgentToolValue(null: ())
             }
+            if let blob = resource.blob {
+                resourceDict["blob"] = AnyAgentToolValue(string: blob)
+            } else {
+                resourceDict["blob"] = AnyAgentToolValue(null: ())
+            }
             return AnyAgentToolValue(object: resourceDict)
+        case let .resourceLink(uri, name, title, description, mimeType, _):
+            var resourceLinkDict: [String: AnyAgentToolValue] = [
+                "type": AnyAgentToolValue(string: "resourceLink"),
+                "uri": AnyAgentToolValue(string: uri),
+                "name": AnyAgentToolValue(string: name),
+            ]
+            resourceLinkDict["title"] = title.map { AnyAgentToolValue(string: $0) } ?? AnyAgentToolValue(null: ())
+            resourceLinkDict["description"] = description.map { AnyAgentToolValue(string: $0) } ?? AnyAgentToolValue(null: ())
+            resourceLinkDict["mimeType"] = mimeType.map { AnyAgentToolValue(string: $0) } ?? AnyAgentToolValue(null: ())
+            return AnyAgentToolValue(object: resourceLinkDict)
         case let .audio(data, mimeType):
             return AnyAgentToolValue(object: [
                 "type": AnyAgentToolValue(string: "audio"),

--- a/Sources/TachikomaMCP/Bridge/TypeConversions.swift
+++ b/Sources/TachikomaMCP/Bridge/TypeConversions.swift
@@ -131,9 +131,12 @@ extension ToolResponse {
             case let .image(data, mimeType, _):
                 // For images, return a descriptive string
                 return AnyAgentToolValue(string: "[Image: \(mimeType), size: \(data.count) bytes]")
-            case let .resource(uri, _, text):
+            case let .resource(resource, _, _):
                 // For resources, return the text content if available
-                return AnyAgentToolValue(string: text ?? "[Resource: \(uri)]")
+                return AnyAgentToolValue(string: resource.text ?? "[Resource: \(resource.uri)]")
+            case let .resourceLink(uri, name, _, _, mimeType, _):
+                let mimeTypeDescription = mimeType.map { ", mimeType: \($0)" } ?? ""
+                return AnyAgentToolValue(string: "[Resource Link: \(name), uri: \(uri)\(mimeTypeDescription)]")
             case let .audio(data, mimeType):
                 return AnyAgentToolValue(string: "[Audio: \(mimeType), size: \(data.count) bytes]")
             }
@@ -180,16 +183,37 @@ extension ToolResponse {
                 "mimeType": AnyAgentToolValue(string: mimeType),
                 "data": AnyAgentToolValue(string: data),
             ])
-        case let .resource(uri, mimeType, text):
+        case let .resource(resource, _, _):
             var resourceDict: [String: AnyAgentToolValue] = [
                 "type": AnyAgentToolValue(string: "resource"),
-                "uri": AnyAgentToolValue(string: uri),
-                "mimeType": AnyAgentToolValue(string: mimeType),
+                "uri": AnyAgentToolValue(string: resource.uri),
             ]
-            if let text {
+            if let mimeType = resource.mimeType {
+                resourceDict["mimeType"] = AnyAgentToolValue(string: mimeType)
+            }
+            if let text = resource.text {
                 resourceDict["text"] = AnyAgentToolValue(string: text)
             }
+            if let blob = resource.blob {
+                resourceDict["blob"] = AnyAgentToolValue(string: blob)
+            }
             return AnyAgentToolValue(object: resourceDict)
+        case let .resourceLink(uri, name, title, description, mimeType, _):
+            var resourceLinkDict: [String: AnyAgentToolValue] = [
+                "type": AnyAgentToolValue(string: "resourceLink"),
+                "uri": AnyAgentToolValue(string: uri),
+                "name": AnyAgentToolValue(string: name),
+            ]
+            if let title {
+                resourceLinkDict["title"] = AnyAgentToolValue(string: title)
+            }
+            if let description {
+                resourceLinkDict["description"] = AnyAgentToolValue(string: description)
+            }
+            if let mimeType {
+                resourceLinkDict["mimeType"] = AnyAgentToolValue(string: mimeType)
+            }
+            return AnyAgentToolValue(object: resourceLinkDict)
         case let .audio(data, mimeType):
             return AnyAgentToolValue(object: [
                 "type": AnyAgentToolValue(string: "audio"),


### PR DESCRIPTION
## Summary
- update TachikomaMCP content conversion to match the current MCP Swift SDK `resource` shape
- add explicit handling for `resourceLink` tool content in adapter and provider conversions
- preserve embedded resource text/blob fields when bridging to `AnyAgentToolValue`

## Testing
- built via `pnpm run build:cli` from the Peekaboo workspace after updating the submodule commit