### PR TITLE
support custom provider credentials in compatible providers

### DIFF
--- a/Sources/Tachikoma/Core/CustomProviders.swift
+++ b/Sources/Tachikoma/Core/CustomProviders.swift
@@ -7,6 +7,7 @@ public struct CustomProviderInfo: Sendable {
     public let id: String
     public let kind: Kind
     public let baseURL: String
+    public let apiKey: String?
     public let headers: [String: String]
     public let models: [String: String] // map of alias->modelId (optional usage)
 }
@@ -29,6 +30,7 @@ public final class CustomProviderRegistry: @unchecked Sendable {
             guard
                 let options = dict["options"] as? [String: Any],
                 let baseURL = options["baseURL"] as? String else { continue }
+            let apiKey = options["apiKey"] as? String
             let headers = options["headers"] as? [String: String] ?? [:]
             var models: [String: String] = [:]
             if let modelsDict = dict["models"] as? [String: Any] {
@@ -36,7 +38,14 @@ public final class CustomProviderRegistry: @unchecked Sendable {
                     if let m = (v as? [String: Any])?["name"] as? String { models[k] = m }
                 }
             }
-            out[id] = CustomProviderInfo(id: id, kind: kind, baseURL: baseURL, headers: headers, models: models)
+            out[id] = CustomProviderInfo(
+                id: id,
+                kind: kind,
+                baseURL: baseURL,
+                apiKey: apiKey,
+                headers: headers,
+                models: models
+            )
         }
         self.providers = out
     }

--- a/Sources/Tachikoma/Providers/Compatible/AnthropicCompatibleProvider.swift
+++ b/Sources/Tachikoma/Providers/Compatible/AnthropicCompatibleProvider.swift
@@ -35,6 +35,20 @@ public final class AnthropicCompatibleProvider: ModelProvider {
         )
     }
 
+    public init(modelId: String, baseURL: String, apiKey: String?) {
+        self.modelId = modelId
+        self.baseURL = baseURL
+        self.apiKey = apiKey
+        self.configuration = TachikomaConfiguration.current
+        self.capabilities = ModelCapabilities(
+            supportsVision: true,
+            supportsTools: true,
+            supportsStreaming: true,
+            contextLength: 200_000,
+            maxOutputTokens: 8192,
+        )
+    }
+
     public func generateText(request: ProviderRequest) async throws -> ProviderResponse {
         let provider = try makeAnthropicProvider()
         return try await provider.generateText(request: request)

--- a/Sources/Tachikoma/Providers/Compatible/OpenAICompatibleProvider.swift
+++ b/Sources/Tachikoma/Providers/Compatible/OpenAICompatibleProvider.swift
@@ -7,10 +7,12 @@ public final class OpenAICompatibleProvider: ModelProvider {
     public let baseURL: String?
     public let apiKey: String?
     public let capabilities: ModelCapabilities
+    private let additionalHeaders: [String: String]
 
     public init(modelId: String, baseURL: String, configuration: TachikomaConfiguration) throws {
         self.modelId = modelId
         self.baseURL = baseURL
+        self.additionalHeaders = [:]
 
         // Try to get API key from configuration, otherwise try common environment variable patterns
         if let key = configuration.getAPIKey(for: .custom("openai_compatible")) {
@@ -33,6 +35,26 @@ public final class OpenAICompatibleProvider: ModelProvider {
         )
     }
 
+    public init(
+        modelId: String,
+        baseURL: String,
+        apiKey: String?,
+        headers: [String: String] = [:],
+        capabilities: ModelCapabilities = ModelCapabilities(
+            supportsVision: true,
+            supportsTools: true,
+            supportsStreaming: true,
+            contextLength: 128_000,
+            maxOutputTokens: 4096,
+        )
+    ) {
+        self.modelId = modelId
+        self.baseURL = baseURL
+        self.apiKey = apiKey
+        self.additionalHeaders = headers
+        self.capabilities = capabilities
+    }
+
     public func generateText(request: ProviderRequest) async throws -> ProviderResponse {
         // Use OpenAI-compatible implementation
         try await OpenAICompatibleHelper.generateText(
@@ -41,6 +63,7 @@ public final class OpenAICompatibleProvider: ModelProvider {
             baseURL: self.baseURL!,
             apiKey: self.apiKey ?? "",
             providerName: "OpenAICompatible",
+            additionalHeaders: self.additionalHeaders,
         )
     }
 
@@ -52,6 +75,7 @@ public final class OpenAICompatibleProvider: ModelProvider {
             baseURL: self.baseURL!,
             apiKey: self.apiKey ?? "",
             providerName: "OpenAICompatible",
+            additionalHeaders: self.additionalHeaders,
         )
     }
 }


### PR DESCRIPTION
## what i expected

peekaboo lets me configure custom openai/anthropic-compatible providers, so i expected those providers to be usable with real per-provider auth and config, not just base urls.

## what i ran into

when trying to route peekaboo image analysis through a local openai-compatible proxy, the custom provider config was not enough to instantiate the provider cleanly with its own auth/config.

## root cause

custom providers were parsed, but the provider info did not carry `apiKey`, and the compatible provider types did not have a simple direct init path for config-driven construction.

## fix

this changes custom-provider plumbing so it can actually be used by callers like peekaboo:

- store `apiKey` in `CustomProviderInfo`
- read `options.apiKey` from custom provider config
- add direct init paths for:
  - `OpenAICompatibleProvider`
  - `AnthropicCompatibleProvider`
- allow passing custom headers through the openai-compatible path

this keeps the change narrow and just makes custom providers actually usable from config.