### PR TITLE
fix(google): drop orphan `required` entries before sending to Gemini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - SwiftPM consumers can now resolve Commander remotely instead of requiring a local `../Commander` checkout. Thanks @malpern.
 - Custom OpenAI-compatible and Anthropic-compatible providers now honor per-provider `options.apiKey` values from profile config. Thanks @381181295.
 - Google/Gemini request encoding now sends tool results as documented user `functionResponse` turns and merges consecutive same-role contents before calling the API. Thanks @hsrvc.
+- Google/Gemini tool schemas now drop orphan `required` entries before request encoding so Gemini accepts simplified MCP tool definitions. Thanks @bcharleson.
 - OpenAI Responses API providers now resolve shared OAuth/API-key credentials instead of requiring `OPENAI_API_KEY` directly.
 - Credential loading now only maps exact API-key credential names to provider API keys, so OAuth access/refresh tokens no longer overwrite configured OpenAI or Anthropic keys.
 - Custom OpenAI-compatible and Anthropic-compatible providers now forward configured proxy headers to request calls.

--- a/Sources/Tachikoma/Providers/Google/GoogleProvider.swift
+++ b/Sources/Tachikoma/Providers/Google/GoogleProvider.swift
@@ -284,12 +284,6 @@ extension GoogleProvider {
     }
 
     private static func convertTool(_ tool: AgentTool) throws -> GoogleGenerateRequest.Tool.FunctionDeclaration {
-        var parameters: [String: Any] = [
-            "type": "object",
-            "properties": [:],
-            "required": tool.parameters.required,
-        ]
-
         var properties: [String: Any] = [:]
         for (key, prop) in tool.parameters.properties {
             var propDict: [String: Any] = [
@@ -308,7 +302,29 @@ extension GoogleProvider {
             }
             properties[key] = propDict
         }
-        parameters["properties"] = properties
+
+        // Gemini validates that every name in `required` exists in `properties`. Tools occasionally
+        // ship with a `required` entry whose property got filtered out during MCP→Agent conversion
+        // (e.g. anyOf/oneOf schemas that don't survive the simplified MCP→Agent translation). Drop
+        // any orphan `required` names so we never send Gemini an invalid schema.
+        let declaredKeys = Set(properties.keys)
+        let sanitizedRequired = tool.parameters.required.filter { declaredKeys.contains($0) }
+        let orphanRequired = tool.parameters.required.filter { !declaredKeys.contains($0) }
+        if !orphanRequired.isEmpty {
+            FileHandle.standardError.write(Data(
+                """
+                [Tachikoma/Google] Tool '\(tool.name)' lists required parameters that are not in `properties`: \
+                \(orphanRequired). Dropping them from the Gemini request to keep the schema valid.\n
+                """.utf8))
+        }
+
+        var parameters: [String: Any] = [
+            "type": "object",
+            "properties": properties,
+        ]
+        if !sanitizedRequired.isEmpty {
+            parameters["required"] = sanitizedRequired
+        }
 
         guard let schema = JSONValue(value: parameters) else {
             throw TachikomaError.invalidInput("Failed to encode tool parameters for '\(tool.name)'")

--- a/Sources/Tachikoma/Providers/Google/GoogleProvider.swift
+++ b/Sources/Tachikoma/Providers/Google/GoogleProvider.swift
@@ -309,14 +309,6 @@ extension GoogleProvider {
         // any orphan `required` names so we never send Gemini an invalid schema.
         let declaredKeys = Set(properties.keys)
         let sanitizedRequired = tool.parameters.required.filter { declaredKeys.contains($0) }
-        let orphanRequired = tool.parameters.required.filter { !declaredKeys.contains($0) }
-        if !orphanRequired.isEmpty {
-            FileHandle.standardError.write(Data(
-                """
-                [Tachikoma/Google] Tool '\(tool.name)' lists required parameters that are not in `properties`: \
-                \(orphanRequired). Dropping them from the Gemini request to keep the schema valid.\n
-                """.utf8))
-        }
 
         var parameters: [String: Any] = [
             "type": "object",

--- a/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
+++ b/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
@@ -145,6 +145,79 @@ struct ProviderEndToEndTests {
         }
     }
 
+    @Test
+    func `Google provider drops orphan required tool parameters`() async throws {
+        let tool = AgentTool(
+            name: "search",
+            description: "Search files",
+            parameters: AgentToolParameters(
+                properties: [
+                    "query": AgentToolParameterProperty(
+                        name: "query",
+                        type: .string,
+                        description: "Search query",
+                    ),
+                ],
+                required: ["query", "mode"],
+            ),
+        ) { _ in
+            AnyAgentToolValue(string: "ok")
+        }
+        let orphanOnlyTool = AgentTool(
+            name: "noop",
+            description: "No-op",
+            parameters: AgentToolParameters(
+                properties: [
+                    "reason": AgentToolParameterProperty(
+                        name: "reason",
+                        type: .string,
+                        description: "Reason",
+                    ),
+                ],
+                required: ["missing"],
+            ),
+        ) { _ in
+            AnyAgentToolValue(string: "ok")
+        }
+
+        let providerRequest = ProviderRequest(
+            messages: [ModelMessage(role: .user, content: [.text("Find it")])],
+            tools: [tool, orphanOnlyTool],
+            settings: .init(maxTokens: 32),
+        )
+
+        try await NetworkMocking.withMockedNetwork { request in
+            let body = try #require(self.bodyData(from: request))
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let tools = try #require(json["tools"] as? [[String: Any]])
+            let declarations = try #require(tools.first?["functionDeclarations"] as? [[String: Any]])
+            let parametersByName = Dictionary(
+                uniqueKeysWithValues: try declarations.map { declaration in
+                    (
+                        try #require(declaration["name"] as? String),
+                        try #require(declaration["parameters"] as? [String: Any])
+                    )
+                },
+            )
+            let searchParameters = try #require(parametersByName["search"])
+            let noopParameters = try #require(parametersByName["noop"])
+
+            #expect(searchParameters["properties"] as? [String: Any] != nil)
+            #expect(searchParameters["required"] as? [String] == ["query"])
+            #expect(noopParameters["properties"] as? [String: Any] != nil)
+            #expect(noopParameters["required"] == nil)
+
+            return NetworkMocking.streamResponse(for: request, data: Self.googleStreamPayload(text: "Done"))
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setAPIKey("google-live", for: .google)
+            }
+            let provider = try GoogleProvider(model: .gemini25Flash, configuration: config)
+            let response = try await provider.generateText(request: providerRequest)
+            #expect(response.text.contains("Done"))
+        }
+    }
+
     // MARK: - OpenAI-compatible providers
 
     @Test


### PR DESCRIPTION
## Summary

Gemini's `GenerateContentRequest` validator rejects tool schemas where `required` contains a property name that is not declared in `properties` with `HTTP 400 - property is not defined`. OpenAI and Anthropic accept the same invalid schema silently, so this class of bug stays hidden until you point a Gemini-backed agent at a real toolset.

This patch hardens `GoogleProvider.convertTool` so it never ships such a schema:

- Build `properties` first.
- Filter `tool.parameters.required` against the resulting key set.
- Emit a one-line `stderr` warning when an orphan name is dropped so the upstream tool definition can be fixed.
- Only attach `required` to the request when the filtered set is non-empty.

## Reproduction

A real-world trigger is Peekaboo's `set_value` agent tool, whose `value` parameter uses an `anyOf` schema. The MCP→Agent converter in Peekaboo currently drops `anyOf` properties (companion fix: openclaw/Peekaboo PR linked below), leaving `value` in `required` with no matching property. With the unfixed Tachikoma:

```
$ peekaboo agent --model gemini-3-flash "use list_apps once"
Error: API error: Google API request failed (HTTP 400): {
  "error": {
    "code": 400,
    "message": "* GenerateContentRequest.tools[0].function_declarations[7].parameters.required[1]: property is not defined\n",
    "status": "INVALID_ARGUMENT"
  }
}
```

After this patch, the request succeeds and stderr carries:

```
[Tachikoma/Google] Tool 'set_value' lists required parameters that are not in `properties`: ["value"]. Dropping them from the Gemini request to keep the schema valid.
```

## Why this is the right layer

The orphan-required mismatch can come from any caller that builds AgentTool by hand or by converting a richer schema. Catching it at the provider boundary keeps every Tachikoma host safe by default; surfacing the warning to stderr nudges the offending tool definition to get fixed at the source.

## Companion fix

The root-cause `anyOf`/`oneOf` drop in PeekabooAgentRuntime is being fixed in parallel: openclaw/Peekaboo#TBD (will link once opened).

## Test plan

- [x] `swift build` (within Peekaboo super-repo against this branch via submodule)
- [x] `peekaboo agent --max-steps 3 "Use list_apps once and summarize, then call done"` end-to-end with Gemini 2.5 Flash — passes, 5.2s, 2 tool calls
- [x] `pnpm run test:safe` in Peekaboo (426 tests, 62 suites) — passes
- [ ] Tachikoma's own integration tests not run here; the change is additive and only affects the request-serialisation path

Made with [Cursor](https://cursor.com)