### PR TITLE
fix(config): annotate loadFromEnvironment @inline(never) to work around Swift release-mode inliner bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - OpenAI Responses API providers now resolve shared OAuth/API-key credentials instead of requiring `OPENAI_API_KEY` directly.
 - Credential loading now only maps exact API-key credential names to provider API keys, so OAuth access/refresh tokens no longer overwrite configured OpenAI or Anthropic keys.
 - Custom OpenAI-compatible and Anthropic-compatible providers now forward configured proxy headers to request calls.
+- Anthropic base URL environment overrides now survive Swift release builds, so `ANTHROPIC_BASE_URL` can route requests through local proxies. Thanks @shraderdm.
 
 ## [0.2.0] - 2026-04-28
 

--- a/Sources/Tachikoma/Core/Configuration.swift
+++ b/Sources/Tachikoma/Core/Configuration.swift
@@ -281,7 +281,17 @@ public final class TachikomaConfiguration: @unchecked Sendable {
         self.loadFromEnvironment()
     }
 
-    /// Load configuration from environment variables
+    /// Load configuration from environment variables.
+    ///
+    /// Marked `@inline(never)` to work around a Swift release-mode optimizer
+    /// issue where inlining this function into the singleton-init path causes
+    /// the `_baseURLs[.anthropic]` write to be incorrectly eliminated, leaving
+    /// `AnthropicProvider.init` reading a stale (default) value via
+    /// `getBaseURL`. OpenAI / Ollama / MiniMax / Azure writes happen to
+    /// survive the optimization; only Anthropic is empirically affected.
+    /// Removing this annotation reintroduces the bug observed in
+    /// openclaw/Peekaboo release builds for `claude-*` models. See #17.
+    @inline(never)
     private func loadFromEnvironment() {
         // Load API keys for all standard providers from environment
         for provider in Provider.standardProviders {

--- a/Tests/TachikomaTests/Core/ConfigurationEnvironmentTests.swift
+++ b/Tests/TachikomaTests/Core/ConfigurationEnvironmentTests.swift
@@ -33,4 +33,17 @@ struct ConfigurationEnvironmentTests {
         let configuration = TachikomaConfiguration(loadFromEnvironment: true)
         #expect(configuration.getBaseURL(for: .openai) == "https://env.example.com")
     }
+
+    @Test
+    func `TachikomaConfiguration picks up ANTHROPIC_BASE_URL from environment`() {
+        let key = "ANTHROPIC_BASE_URL"
+        setenv(key, "https://env.example.com", 1)
+        defer { unsetenv(key) }
+
+        let rawValue = Provider.environmentValue(for: key)
+        #expect(rawValue == "https://env.example.com")
+
+        let configuration = TachikomaConfiguration(loadFromEnvironment: true)
+        #expect(configuration.getBaseURL(for: .anthropic) == "https://env.example.com")
+    }
 }


### PR DESCRIPTION
Closes #17.

In Swift 6 release builds, inlining `loadFromEnvironment` into the singleton-init path causes the `_baseURLs[.anthropic]` write to be incorrectly eliminated by the optimizer, leaving `AnthropicProvider.init` reading a stale (default) value via `getBaseURL`. OpenAI / Ollama / MiniMax / Azure writes happen to survive the optimization; only Anthropic is empirically affected. The annotation prevents the inlining and the bug disappears.

### Empirical evidence

| Configuration | Result |
|---|---|
| Unpatched release binary, `ANTHROPIC_BASE_URL=http://127.0.0.1:1` | 4/4 runs: env IGNORED, requests landed at `api.anthropic.com` (real Claude responses) |
| Patched release binary (this change), same env | 3/3 runs: env HONORED, request fails with "Could not connect" as expected |
| Same release binary for OpenAI (`OPENAI_BASE_URL=closed`) | env HONORED (Anthropic-specific bug, not generic) |
| Debug builds (any provider) | env HONORED (less aggressive inlining) |
| `swift test` (debug by default) | env HONORED |
| Release build with any observable side effect added in the loop body | env HONORED (defeats the elimination) |

The bug doesn't reproduce in the swift-testing harness because that runs in debug mode. Reproduced via openclaw/Peekaboo release builds.

### Changes

| File | Change |
|---|---|
| `Sources/Tachikoma/Core/Configuration.swift` | Add `@inline(never)` annotation + extended doc comment on `loadFromEnvironment` (the doc is the durable guard against accidental removal) |
| `Tests/TachikomaTests/Core/ConfigurationEnvironmentTests.swift` | Add `TachikomaConfiguration picks up ANTHROPIC_BASE_URL from environment` test, mirroring the existing `OPENAI_BASE_URL` test pattern |

### Caveat on the test

The test passes in debug mode regardless of the annotation, so it cannot catch a regression of removing `@inline(never)` (the inliner bug is release-mode-only). Covering the regression would need a release-mode integration test, which is out of scope for the swift-testing harness. The annotation's doc comment is the actual durable guard.

### Verification

```
$ swift test --filter "ConfigurationEnvironmentTests"
✔ Test "Provider.environmentValue falls back to process environment" passed
✔ Test "TachikomaConfiguration picks up base URLs from environment" passed
✔ Test "TachikomaConfiguration picks up ANTHROPIC_BASE_URL from environment" passed
✔ Test run with 3 tests in 1 suite passed

$ swift test
✔ Test run with 594 tests in 102 suites passed after 10.224 seconds.
```

Swift 6.2.4 / macOS 26.5.

### Investigation history

For the curious: initial PR was a construction-time env read in `AnthropicProvider.init`. That worked empirically but didn't address the root cause. Diagnostic instrumentation in `loadFromEnvironment` hid the bug, which suggested optimization-dependent behavior. Adding `@inline(never)` without any diagnostic prints reproduced the fix, identifying the inliner as the trigger.
