### PR TITLE
feat(models): add Kimi (Moonshot) provider with K2.6 and K2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 ### Added
 - Added first-class OpenAI `chat-latest` support with parsing aliases, Responses API routing, model capabilities, and usage estimates.
 - Added first-class MiniMax support with the `MiniMax-M2.7` catalog models, `MINIMAX_API_KEY` / `MINIMAX_BASE_URL` configuration, bearer-token Anthropic-compatible transport, model parsing shortcuts, usage estimates, and provider tests.
+- Added first-class Kimi support for the official K2.6 and K2.7 Code model IDs, Moonshot's OpenAI-compatible endpoint, multimodal/tool capabilities, and provider-bound `reasoning_content` replay. Thanks @Tugser.
 - Added explicit LM Studio model shortcuts such as `lmstudio` and `lmstudio/openai/gpt-oss-120b` so local provider selections no longer fall through to Ollama custom IDs.
 
 ### Changed

--- a/Examples/AI-CLI/Sources/AI-CLI.swift
+++ b/Examples/AI-CLI/Sources/AI-CLI.swift
@@ -415,6 +415,10 @@ struct AICLI {
             print("export MINIMAX_CN_API_KEY='your-key-here'")
             print("# or reuse the global MiniMax key name:")
             print("export MINIMAX_API_KEY='your-key-here'")
+        case .kimi:
+            print("Set your Moonshot AI API key:")
+            print("export MOONSHOT_API_KEY='your-key-here'")
+            print("Setup guide: https://platform.kimi.com/docs/guide/start-using-kimi-api")
         case .mistral:
             print("Set your Mistral API key:")
             print("export MISTRAL_API_KEY='your-key-here'")

--- a/Examples/AI-CLI/Sources/AI-CLI.swift
+++ b/Examples/AI-CLI/Sources/AI-CLI.swift
@@ -376,6 +376,7 @@ struct AICLI {
         case .google: .google
         case .minimax: .minimax
         case .minimaxCN: .minimaxCN
+        case .kimi: .kimi
         case .mistral: .mistral
         case .groq: .groq
         case .grok: .grok

--- a/Examples/AI-CLI/Sources/AI-CLI.swift
+++ b/Examples/AI-CLI/Sources/AI-CLI.swift
@@ -418,7 +418,7 @@ struct AICLI {
         case .kimi:
             print("Set your Moonshot AI API key:")
             print("export MOONSHOT_API_KEY='your-key-here'")
-            print("Setup guide: https://platform.kimi.com/docs/guide/start-using-kimi-api")
+            print("Setup guide: https://platform.kimi.ai/docs/guide/start-using-kimi-api")
         case .mistral:
             print("Set your Mistral API key:")
             print("export MISTRAL_API_KEY='your-key-here'")

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Common picks:
 - OpenAI: `gpt-5.5` (`LanguageModel.defaultStreaming`), `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.4-nano`, `gpt-5`
 - Google: `gemini-3.1-pro-preview`, `gemini-3-flash`
 - Grok: `grok-4.3`
+- MiniMax: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`
+- Kimi: `kimi-k2.6`, `kimi-k2.7-code`, `kimi-k2.7-code-highspeed`
 - Local: `ollama/llama3.3`
 
 Full catalog (including enum case names + provider notes): [`docs/models.md`](docs/models.md).
@@ -115,6 +117,8 @@ Set API keys via env vars (or use `TKAuthManager`):
 - Anthropic: `ANTHROPIC_API_KEY`
 - Gemini: `GEMINI_API_KEY` (alias: `GOOGLE_API_KEY`)
 - Grok: `X_AI_API_KEY` (aliases: `XAI_API_KEY`, `GROK_API_KEY`)
+- MiniMax: `MINIMAX_API_KEY`
+- Kimi (Moonshot AI): `MOONSHOT_API_KEY` (alias: `KIMI_API_KEY`)
 
 Hosts can change the credential storage root:
 - `TachikomaConfiguration.profileDirectoryName` (Peekaboo uses `.peekaboo`)

--- a/Sources/Tachikoma/Core/Configuration.swift
+++ b/Sources/Tachikoma/Core/Configuration.swift
@@ -357,6 +357,7 @@ public final class TachikomaConfiguration: @unchecked Sendable {
             .anthropic: "ANTHROPIC_BASE_URL",
             .minimax: "MINIMAX_BASE_URL",
             .minimaxCN: "MINIMAX_CN_BASE_URL",
+            .kimi: "MOONSHOT_BASE_URL",
             .ollama: "OLLAMA_BASE_URL",
             .azureOpenAI: "AZURE_OPENAI_ENDPOINT",
         ]

--- a/Sources/Tachikoma/Core/Generation.swift
+++ b/Sources/Tachikoma/Core/Generation.swift
@@ -789,6 +789,7 @@ extension LanguageModel {
              .mistral,
              .groq,
              .grok,
+             .kimi,
              .azureOpenAI:
             return true
         case let .custom(provider):
@@ -939,6 +940,29 @@ extension [ModelMessage] {
             return sanitized
         }
 
+        if let target = model.kimiReasoningReplayTarget(configuration: configuration) {
+            var sanitized: [ModelMessage] = []
+            for message in self {
+                if message.isSyntheticReasoningBoundary {
+                    if sanitized.last?.channel == .thinking {
+                        sanitized.append(message)
+                    }
+                    continue
+                }
+                guard message.channel == .thinking else {
+                    sanitized.append(message)
+                    continue
+                }
+                guard message.hasKimiReasoningReplayMetadata else {
+                    continue
+                }
+                if target.matches(message.metadata?.customData ?? [:]) {
+                    sanitized.append(message)
+                }
+            }
+            return sanitized
+        }
+
         return self.filter { !$0.isSyntheticReasoningBoundary && $0.channel != .thinking }
     }
 }
@@ -957,8 +981,13 @@ extension ModelMessage {
             customData["openrouter.reasoning"] != nil
     }
 
+    fileprivate var hasKimiReasoningReplayMetadata: Bool {
+        self.metadata?.customData?["kimi.reasoning_content"] != nil
+    }
+
     private var hasProviderReasoningReplayMetadata: Bool {
-        self.hasAnthropicThinkingReplayMetadata || self.hasOpenRouterReasoningReplayMetadata
+        self.hasAnthropicThinkingReplayMetadata || self.hasOpenRouterReasoningReplayMetadata ||
+            self.hasKimiReasoningReplayMetadata
     }
 
     fileprivate var isSyntheticReasoningBoundary: Bool {
@@ -1142,12 +1171,41 @@ extension LanguageModel {
         }
     }
 
+    fileprivate func kimiReasoningReplayTarget(configuration: TachikomaConfiguration) -> ReasoningReplayTarget? {
+        switch self {
+        case let .kimi(model):
+            ReasoningReplayTarget(
+                provider: "kimi",
+                modelId: model.modelId,
+                baseURL: configuration.getBaseURL(for: .kimi) ?? Provider.kimi.defaultBaseURL,
+                allowsLegacyUnknown: false,
+            )
+        default:
+            nil
+        }
+    }
+
     private func anthropicThinkingMetadata(
         for reasoning: ProviderReasoningBlock,
         configuration: TachikomaConfiguration,
     )
         -> [String: String]
     {
+        if
+            reasoning.type == "kimi_reasoning_content",
+            let target = self.kimiReasoningReplayTarget(configuration: configuration)
+        {
+            var metadata = [
+                "kimi.reasoning_content": reasoning.text,
+                "tachikoma.reasoning.type": reasoning.type,
+                "tachikoma.reasoning.provider": target.provider,
+                "tachikoma.reasoning.model": target.modelId,
+            ]
+            if let endpointIdentity = target.endpointIdentity {
+                metadata["tachikoma.reasoning.base_url"] = endpointIdentity
+            }
+            return metadata
+        }
         if
             let rawJSON = reasoning.rawJSON,
             let target = self.openRouterReasoningReplayTarget(configuration: configuration)

--- a/Sources/Tachikoma/Core/ModelCapabilities.swift
+++ b/Sources/Tachikoma/Core/ModelCapabilities.swift
@@ -210,6 +210,8 @@ public final class ModelCapabilityRegistry: @unchecked Sendable {
             "minimax:\(submodel.modelId)"
         case let .minimaxCN(submodel):
             "minimax-cn:\(submodel.modelId)"
+        case let .kimi(submodel):
+            "kimi:\(submodel.modelId)"
         case let .openRouter(modelId):
             "openrouter:\(modelId)"
         case let .together(modelId):

--- a/Sources/Tachikoma/Core/ModelCapabilities.swift
+++ b/Sources/Tachikoma/Core/ModelCapabilities.swift
@@ -339,6 +339,19 @@ public final class ModelCapabilityRegistry: @unchecked Sendable {
         self.capabilities["grok:grok-4.3"] = grokCapabilities
         self.capabilities["grok:grok-4.20-0309-reasoning"] = grokCapabilities
         self.capabilities["grok:grok-4.20-0309-non-reasoning"] = grokCapabilities
+
+        // Current Kimi thinking models require fixed sampling values.
+        let kimiCapabilities = ModelParameterCapabilities(
+            supportsTopP: false,
+            supportsFrequencyPenalty: false,
+            supportsPresencePenalty: false,
+            maxTokenLimit: 32768,
+            forcedTemperature: 1,
+            excludedParameters: ["topP", "frequencyPenalty", "presencePenalty"],
+        )
+        for model in LanguageModel.Kimi.allCases {
+            self.capabilities["kimi:\(model.modelId)"] = kimiCapabilities
+        }
     }
 
     private func defaultCapabilities(for model: LanguageModel) -> ModelParameterCapabilities {

--- a/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
+++ b/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
@@ -45,20 +45,22 @@ struct OpenAICompatibleHelper {
         let stopSequences = Self.extractStopSequences(from: settings.stopConditions)
 
         // Convert request to OpenAI-compatible format
+        let messages = try self.convertMessages(
+            request.messages,
+            replayOpenRouterReasoningForModel: providerName == "OpenRouter" ? modelId : nil,
+            replayOpenRouterReasoningForBaseURL: providerName == "OpenRouter" ? baseURL : nil,
+            replayKimiReasoningForModel: providerName == "Kimi" ? modelId : nil,
+            replayKimiReasoningForBaseURL: providerName == "Kimi" ? baseURL : nil,
+        )
         let openAIRequest = try OpenAIChatRequest(
             model: modelId,
-            messages: convertMessages(
-                request.messages,
-                replayOpenRouterReasoningForModel: providerName == "OpenRouter" ? modelId : nil,
-                replayOpenRouterReasoningForBaseURL: providerName == "OpenRouter" ? baseURL : nil,
-                replayKimiReasoningForModel: providerName == "Kimi" ? modelId : nil,
-                replayKimiReasoningForBaseURL: providerName == "Kimi" ? baseURL : nil,
-            ),
+            messages: messages,
             temperature: settings.temperature,
             maxTokens: settings.maxTokens,
             tools: request.tools?.compactMap { try self.convertTool($0) },
             stream: false,
             stop: stopSequences.isEmpty ? nil : stopSequences,
+            thinking: Self.kimiThinkingConfiguration(providerName: providerName, modelId: modelId, messages: messages),
         )
 
         let encoder = JSONEncoder()
@@ -193,20 +195,22 @@ struct OpenAICompatibleHelper {
         let stopSequences = Self.extractStopSequences(from: settings.stopConditions)
 
         // Convert request to OpenAI-compatible format
+        let messages = try self.convertMessages(
+            request.messages,
+            replayOpenRouterReasoningForModel: providerName == "OpenRouter" ? modelId : nil,
+            replayOpenRouterReasoningForBaseURL: providerName == "OpenRouter" ? baseURL : nil,
+            replayKimiReasoningForModel: providerName == "Kimi" ? modelId : nil,
+            replayKimiReasoningForBaseURL: providerName == "Kimi" ? baseURL : nil,
+        )
         let openAIRequest = try OpenAIChatRequest(
             model: modelId,
-            messages: convertMessages(
-                request.messages,
-                replayOpenRouterReasoningForModel: providerName == "OpenRouter" ? modelId : nil,
-                replayOpenRouterReasoningForBaseURL: providerName == "OpenRouter" ? baseURL : nil,
-                replayKimiReasoningForModel: providerName == "Kimi" ? modelId : nil,
-                replayKimiReasoningForBaseURL: providerName == "Kimi" ? baseURL : nil,
-            ),
+            messages: messages,
             temperature: settings.temperature,
             maxTokens: settings.maxTokens,
             tools: request.tools?.compactMap { try self.convertTool($0) },
             stream: true,
             stop: stopSequences.isEmpty ? nil : stopSequences,
+            thinking: Self.kimiThinkingConfiguration(providerName: providerName, modelId: modelId, messages: messages),
         )
 
         let encoder = JSONEncoder()
@@ -595,6 +599,24 @@ struct OpenAICompatibleHelper {
         } else {
             return "unknown"
         }
+    }
+
+    private static func kimiThinkingConfiguration(
+        providerName: String,
+        modelId: String,
+        messages: [OpenAIChatMessage],
+    )
+        -> OpenAIThinkingConfiguration?
+    {
+        guard
+            providerName == "Kimi",
+            modelId == LanguageModel.Kimi.k26.modelId,
+            messages.contains(where: { $0.reasoningContent?.isEmpty == false }) else
+        {
+            return nil
+        }
+
+        return OpenAIThinkingConfiguration(type: "enabled", keep: "all")
     }
 
     private static func convertMessages(

--- a/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
+++ b/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
@@ -51,6 +51,8 @@ struct OpenAICompatibleHelper {
                 request.messages,
                 replayOpenRouterReasoningForModel: providerName == "OpenRouter" ? modelId : nil,
                 replayOpenRouterReasoningForBaseURL: providerName == "OpenRouter" ? baseURL : nil,
+                replayKimiReasoningForModel: providerName == "Kimi" ? modelId : nil,
+                replayKimiReasoningForBaseURL: providerName == "Kimi" ? baseURL : nil,
             ),
             temperature: settings.temperature,
             maxTokens: settings.maxTokens,
@@ -110,7 +112,7 @@ struct OpenAICompatibleHelper {
         let usage = openAIResponse.usage.map {
             Usage(inputTokens: $0.promptTokens ?? 0, outputTokens: $0.completionTokens ?? 0)
         }
-        let reasoning = Self.reasoningBlocks(from: choice.message)
+        let reasoning = Self.reasoningBlocks(from: choice.message, providerName: providerName)
 
         let finishReason = Self.mapFinishReason(choice.finishReason)
 
@@ -197,6 +199,8 @@ struct OpenAICompatibleHelper {
                 request.messages,
                 replayOpenRouterReasoningForModel: providerName == "OpenRouter" ? modelId : nil,
                 replayOpenRouterReasoningForBaseURL: providerName == "OpenRouter" ? baseURL : nil,
+                replayKimiReasoningForModel: providerName == "Kimi" ? modelId : nil,
+                replayKimiReasoningForBaseURL: providerName == "Kimi" ? baseURL : nil,
             ),
             temperature: settings.temperature,
             maxTokens: settings.maxTokens,
@@ -322,6 +326,18 @@ struct OpenAICompatibleHelper {
                                         hasReceivedContent = true
                                     }
 
+                                    if
+                                        providerName == "Kimi",
+                                        let reasoning = choice.delta.reasoningContent,
+                                        !reasoning.isEmpty
+                                    {
+                                        continuation.yield(TextStreamDelta.reasoning(
+                                            reasoning,
+                                            type: "kimi_reasoning_content",
+                                        ))
+                                        hasReceivedContent = true
+                                    }
+
                                     // Handle tool calls - Grok sends them all at once
                                     if let toolCalls = choice.delta.toolCalls {
                                         for toolCall in toolCalls {
@@ -417,6 +433,18 @@ struct OpenAICompatibleHelper {
                                         hasReceivedContent = true
                                     }
 
+                                    if
+                                        providerName == "Kimi",
+                                        let reasoning = choice.delta.reasoningContent,
+                                        !reasoning.isEmpty
+                                    {
+                                        continuation.yield(TextStreamDelta.reasoning(
+                                            reasoning,
+                                            type: "kimi_reasoning_content",
+                                        ))
+                                        hasReceivedContent = true
+                                    }
+
                                     // Handle tool calls - Grok sends them all at once
                                     if let toolCalls = choice.delta.toolCalls {
                                         for toolCall in toolCalls {
@@ -502,6 +530,8 @@ struct OpenAICompatibleHelper {
 
     private static func languageModel(providerName: String, modelId: String, baseURL: String) -> LanguageModel {
         switch providerName.lowercased() {
+        case "kimi":
+            .kimi(LanguageModel.Kimi(rawValue: modelId) ?? .k26)
         case "openrouter":
             .openRouter(modelId: modelId)
         case "together":
@@ -571,6 +601,8 @@ struct OpenAICompatibleHelper {
         _ messages: [ModelMessage],
         replayOpenRouterReasoningForModel modelId: String?,
         replayOpenRouterReasoningForBaseURL baseURL: String?,
+        replayKimiReasoningForModel kimiModelId: String?,
+        replayKimiReasoningForBaseURL kimiBaseURL: String?,
     ) throws
         -> [OpenAIChatMessage]
     {
@@ -578,6 +610,8 @@ struct OpenAICompatibleHelper {
         var pendingReasoningDetails: [JSONValue] = []
         var pendingReasoningText: [String] = []
         let endpointIdentity = ReasoningEndpointIdentity.canonical(baseURL)
+        var pendingKimiReasoningContent: [String] = []
+        let kimiEndpointIdentity = ReasoningEndpointIdentity.canonical(kimiBaseURL)
 
         for message in messages {
             if
@@ -589,6 +623,17 @@ struct OpenAICompatibleHelper {
                 let rawReasoningDetails = customData["openrouter.reasoning_details"]
             {
                 pendingReasoningDetails.append(contentsOf: Self.decodeReasoningDetails(rawReasoningDetails))
+                continue
+            }
+            if
+                message.channel == .thinking,
+                let customData = message.metadata?.customData,
+                customData["tachikoma.reasoning.provider"] == "kimi",
+                customData["tachikoma.reasoning.model"] == kimiModelId,
+                customData["tachikoma.reasoning.base_url"] == kimiEndpointIdentity,
+                let reasoning = customData["kimi.reasoning_content"]
+            {
+                pendingKimiReasoningContent.append(reasoning)
                 continue
             }
             if
@@ -669,6 +714,9 @@ struct OpenAICompatibleHelper {
                         toolCalls: toolCalls,
                         reasoning: pendingReasoningText.isEmpty ? nil : pendingReasoningText.joined(separator: "\n"),
                         reasoningDetails: pendingReasoningDetails.isEmpty ? nil : pendingReasoningDetails,
+                        reasoningContent: pendingKimiReasoningContent.isEmpty
+                            ? nil
+                            : pendingKimiReasoningContent.joined(separator: "\n"),
                     ))
                 } else {
                     // Regular text message
@@ -678,10 +726,14 @@ struct OpenAICompatibleHelper {
                         toolCalls: nil,
                         reasoning: pendingReasoningText.isEmpty ? nil : pendingReasoningText.joined(separator: "\n"),
                         reasoningDetails: pendingReasoningDetails.isEmpty ? nil : pendingReasoningDetails,
+                        reasoningContent: pendingKimiReasoningContent.isEmpty
+                            ? nil
+                            : pendingKimiReasoningContent.joined(separator: "\n"),
                     ))
                 }
                 pendingReasoningText.removeAll()
                 pendingReasoningDetails.removeAll()
+                pendingKimiReasoningContent.removeAll()
             case .tool:
                 // Extract tool call ID and result content from tool result
                 var toolCallId: String?
@@ -707,8 +759,23 @@ struct OpenAICompatibleHelper {
         return converted
     }
 
-    private static func reasoningBlocks(from message: OpenAIChatResponse.Message) -> [ProviderReasoningBlock] {
+    private static func reasoningBlocks(
+        from message: OpenAIChatResponse.Message,
+        providerName: String,
+    )
+        -> [ProviderReasoningBlock]
+    {
         var blocks: [ProviderReasoningBlock] = []
+        if
+            providerName == "Kimi",
+            let reasoningContent = message.reasoningContent,
+            !reasoningContent.isEmpty
+        {
+            blocks.append(ProviderReasoningBlock(
+                text: reasoningContent,
+                type: "kimi_reasoning_content",
+            ))
+        }
         if let details = message.reasoningDetails, !details.isEmpty {
             blocks.append(ProviderReasoningBlock(
                 text: message.reasoning ?? "",

--- a/Sources/Tachikoma/Core/Provider.swift
+++ b/Sources/Tachikoma/Core/Provider.swift
@@ -47,7 +47,7 @@ public enum Provider: Sendable, Hashable, Codable {
     /// MiniMax China provider (Anthropic-compatible hosted models)
     case minimaxCN
 
-    /// Kimi provider (Moonshot AI, OpenAI-compatible coding endpoint)
+    /// Kimi provider (Moonshot AI, OpenAI-compatible API)
     case kimi
 
     /// Ollama provider (local model hosting)
@@ -125,7 +125,7 @@ public enum Provider: Sendable, Hashable, Codable {
         case .grok: ["XAI_API_KEY", "GROK_API_KEY"] // Additional Grok aliases
         case .google: ["GOOGLE_API_KEY"] // Backwards compatibility
         case .minimaxCN: ["MINIMAX_API_KEY"]
-        case .kimi: ["KIMI_API_KEY", "MOONSHOT_KEY"] // Additional Kimi/Moonshot aliases
+        case .kimi: ["KIMI_API_KEY"]
         case .azureOpenAI: ["AZURE_OPENAI_TOKEN", "AZURE_OPENAI_BEARER_TOKEN"]
         default: []
         }
@@ -142,7 +142,7 @@ public enum Provider: Sendable, Hashable, Codable {
         case .google: "https://generativelanguage.googleapis.com/v1beta"
         case .minimax: "https://api.minimax.io/anthropic"
         case .minimaxCN: "https://api.minimaxi.com/anthropic"
-        case .kimi: "https://api.kimi.com/coding/v1"
+        case .kimi: "https://api.moonshot.cn/v1"
         case .ollama: "http://localhost:11434"
         case .lmstudio: "http://localhost:1234/v1"
         case .azureOpenAI: nil // Requires resource or endpoint

--- a/Sources/Tachikoma/Core/Provider.swift
+++ b/Sources/Tachikoma/Core/Provider.swift
@@ -142,7 +142,7 @@ public enum Provider: Sendable, Hashable, Codable {
         case .google: "https://generativelanguage.googleapis.com/v1beta"
         case .minimax: "https://api.minimax.io/anthropic"
         case .minimaxCN: "https://api.minimaxi.com/anthropic"
-        case .kimi: "https://api.moonshot.cn/v1"
+        case .kimi: "https://api.moonshot.ai/v1"
         case .ollama: "http://localhost:11434"
         case .lmstudio: "http://localhost:1234/v1"
         case .azureOpenAI: nil // Requires resource or endpoint

--- a/Sources/Tachikoma/Core/Provider.swift
+++ b/Sources/Tachikoma/Core/Provider.swift
@@ -47,6 +47,9 @@ public enum Provider: Sendable, Hashable, Codable {
     /// MiniMax China provider (Anthropic-compatible hosted models)
     case minimaxCN
 
+    /// Kimi provider (Moonshot AI, OpenAI-compatible coding endpoint)
+    case kimi
+
     /// Ollama provider (local model hosting)
     case ollama
 
@@ -70,6 +73,7 @@ public enum Provider: Sendable, Hashable, Codable {
         case .google: "google"
         case .minimax: "minimax"
         case .minimaxCN: "minimax-cn"
+        case .kimi: "kimi"
         case .ollama: "ollama"
         case .lmstudio: "lmstudio"
         case .azureOpenAI: "azure-openai"
@@ -88,6 +92,7 @@ public enum Provider: Sendable, Hashable, Codable {
         case .google: "Google"
         case .minimax: "MiniMax"
         case .minimaxCN: "MiniMax China"
+        case .kimi: "Kimi"
         case .ollama: "Ollama"
         case .lmstudio: "LMStudio"
         case .azureOpenAI: "Azure OpenAI"
@@ -106,6 +111,7 @@ public enum Provider: Sendable, Hashable, Codable {
         case .google: "GEMINI_API_KEY"
         case .minimax: "MINIMAX_API_KEY"
         case .minimaxCN: "MINIMAX_CN_API_KEY"
+        case .kimi: "MOONSHOT_API_KEY"
         case .ollama: "OLLAMA_API_KEY"
         case .lmstudio: "" // LMStudio doesn't need API keys
         case .azureOpenAI: "AZURE_OPENAI_API_KEY"
@@ -119,6 +125,7 @@ public enum Provider: Sendable, Hashable, Codable {
         case .grok: ["XAI_API_KEY", "GROK_API_KEY"] // Additional Grok aliases
         case .google: ["GOOGLE_API_KEY"] // Backwards compatibility
         case .minimaxCN: ["MINIMAX_API_KEY"]
+        case .kimi: ["KIMI_API_KEY", "MOONSHOT_KEY"] // Additional Kimi/Moonshot aliases
         case .azureOpenAI: ["AZURE_OPENAI_TOKEN", "AZURE_OPENAI_BEARER_TOKEN"]
         default: []
         }
@@ -135,6 +142,7 @@ public enum Provider: Sendable, Hashable, Codable {
         case .google: "https://generativelanguage.googleapis.com/v1beta"
         case .minimax: "https://api.minimax.io/anthropic"
         case .minimaxCN: "https://api.minimaxi.com/anthropic"
+        case .kimi: "https://api.kimi.com/coding/v1"
         case .ollama: "http://localhost:11434"
         case .lmstudio: "http://localhost:1234/v1"
         case .azureOpenAI: nil // Requires resource or endpoint
@@ -154,7 +162,7 @@ public enum Provider: Sendable, Hashable, Codable {
 
     /// All standard providers (excludes custom)
     public static var standardProviders: [Provider] {
-        [.openai, .anthropic, .grok, .groq, .mistral, .google, .minimax, .minimaxCN, .ollama, .azureOpenAI]
+        [.openai, .anthropic, .grok, .groq, .mistral, .google, .minimax, .minimaxCN, .kimi, .ollama, .azureOpenAI]
     }
 
     /// Create provider from string identifier
@@ -169,6 +177,7 @@ public enum Provider: Sendable, Hashable, Codable {
         case "google", "gemini": .google
         case "minimax": .minimax
         case "minimax-cn", "minimax_cn", "minimaxi": .minimaxCN
+        case "kimi", "moonshot": .kimi
         case "ollama": .ollama
         case "azure-openai", "azure_openai", "azureopenai": .azureOpenAI
         default: .custom(identifier)

--- a/Sources/Tachikoma/Models/Model.swift
+++ b/Sources/Tachikoma/Models/Model.swift
@@ -389,12 +389,11 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
         }
     }
 
-    /// Kimi (Moonshot AI) models exposed via the OpenAI-compatible coding endpoint.
+    /// Kimi (Moonshot AI) models exposed via the OpenAI-compatible API.
     public enum Kimi: String, Sendable, Hashable, CaseIterable {
-        /// Kimi K2.6 (api id `k2p6`, family kimi-thinking). Multimodal: text/image/video input.
-        case k26 = "k2p6"
-        /// Kimi K2.7 Code (api id `k2p7`, family kimi-k2). Multimodal: text/image/video input.
-        case k27 = "k2p7"
+        case k27Code = "kimi-k2.7-code"
+        case k27CodeHighspeed = "kimi-k2.7-code-highspeed"
+        case k26 = "kimi-k2.6"
 
         public var modelId: String {
             self.rawValue
@@ -1623,23 +1622,27 @@ extension LanguageModel {
         // MARK: Kimi (Moonshot) models
 
         if
-            dashed.contains("kimi-k2.7") ||
-            dotted.contains("kimi-k2-7") ||
-            compact.contains("kimik27") ||
-            compact.contains("k2p7") ||
-            dashed == "k2p7" ||
-            dashed == "k2.7" ||
-            dotted == "k2-7"
+            dashed.contains("kimi-k2.7-code-highspeed") ||
+            dotted.contains("kimi-k2-7-code-highspeed") ||
+            compact.contains("kimik27codehighspeed")
         {
-            return .kimi(.k27)
+            return .kimi(.k27CodeHighspeed)
+        }
+
+        if
+            dashed.contains("kimi-k2.7-code") ||
+            dotted.contains("kimi-k2-7-code") ||
+            compact.contains("kimik27code") ||
+            dashed == "k2.7-code" ||
+            dotted == "k2-7-code"
+        {
+            return .kimi(.k27Code)
         }
 
         if
             dashed.contains("kimi-k2.6") ||
             dotted.contains("kimi-k2-6") ||
             compact.contains("kimik26") ||
-            compact.contains("k2p6") ||
-            dashed == "k2p6" ||
             dashed == "k2.6" ||
             dotted == "k2-6" ||
             normalized == "kimi" ||
@@ -1891,10 +1894,12 @@ extension LanguageModel {
         let normalized = modelString.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
         switch normalized {
-        case "k2p6", "kimi-k2.6", "kimi-k2-6", "kimi-k2p6", "kimi-k2.6-code", "k2.6":
+        case "kimi-k2.6", "kimi-k2-6", "k2.6", "k2-6":
             return .k26
-        case "k2p7", "kimi-k2.7", "kimi-k2-7", "kimi-k2p7", "kimi-k2p7-code", "kimi-k2.7-code", "k2.7", "kimi-k2.7-code-free":
-            return .k27
+        case "kimi-k2.7-code", "kimi-k2-7-code", "k2.7-code", "k2-7-code":
+            return .k27Code
+        case "kimi-k2.7-code-highspeed", "kimi-k2-7-code-highspeed", "k2.7-code-highspeed", "k2-7-code-highspeed":
+            return .k27CodeHighspeed
         default:
             return nil
         }

--- a/Sources/Tachikoma/Models/Model.swift
+++ b/Sources/Tachikoma/Models/Model.swift
@@ -16,6 +16,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
     case lmstudio(LMStudio)
     case minimax(MiniMax)
     case minimaxCN(MiniMax)
+    case kimi(Kimi)
     case azureOpenAI(deployment: String, resource: String? = nil, apiVersion: String? = nil, endpoint: String? = nil)
 
     // Third-party aggregators
@@ -385,6 +386,38 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
 
         public var contextLength: Int {
             204_800
+        }
+    }
+
+    /// Kimi (Moonshot AI) models exposed via the OpenAI-compatible coding endpoint.
+    public enum Kimi: String, Sendable, Hashable, CaseIterable {
+        /// Kimi K2.6 (api id `k2p6`, family kimi-thinking). Multimodal: text/image/video input.
+        case k26 = "k2p6"
+        /// Kimi K2.7 Code (api id `k2p7`, family kimi-k2). Multimodal: text/image/video input.
+        case k27 = "k2p7"
+
+        public var modelId: String {
+            self.rawValue
+        }
+
+        public var supportsVision: Bool {
+            true
+        }
+
+        public var supportsTools: Bool {
+            true
+        }
+
+        public var supportsAudioInput: Bool {
+            false
+        }
+
+        public var supportsAudioOutput: Bool {
+            false
+        }
+
+        public var contextLength: Int {
+            262_144
         }
     }
 
@@ -763,6 +796,8 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             return "MiniMax/\(model.modelId)"
         case let .minimaxCN(model):
             return "MiniMax China/\(model.modelId)"
+        case let .kimi(model):
+            return "Kimi/\(model.modelId)"
         case let .azureOpenAI(deployment, resource, apiVersion, endpoint):
             let host = endpoint ?? resource ?? "endpoint"
             let version = apiVersion ?? "api-version-default"
@@ -804,6 +839,8 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             model.modelId
         case let .minimaxCN(model):
             model.modelId
+        case let .kimi(model):
+            model.modelId
         case let .azureOpenAI(deployment, _, _, _):
             deployment
         case let .openRouter(modelId):
@@ -842,6 +879,8 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
         case let .minimax(model):
             model.supportsVision
         case let .minimaxCN(model):
+            model.supportsVision
+        case let .kimi(model):
             model.supportsVision
         case .azureOpenAI:
             true // Azure mirrors OpenAI models with vision support when available
@@ -916,6 +955,8 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             "MiniMax"
         case .minimaxCN:
             "MiniMax China"
+        case .kimi:
+            "Kimi"
         case .openRouter:
             "OpenRouter"
         case .together:
@@ -974,6 +1015,8 @@ extension LanguageModel {
             model.supportsAudioInput
         case let .minimaxCN(model):
             model.supportsAudioInput
+        case let .kimi(model):
+            model.supportsAudioInput
         case .azureOpenAI:
             false // Azure chat endpoints currently omit audio input
         case .openRouter, .together, .replicate:
@@ -1006,6 +1049,8 @@ extension LanguageModel {
         case let .minimax(model):
             model.supportsAudioOutput
         case let .minimaxCN(model):
+            model.supportsAudioOutput
+        case let .kimi(model):
             model.supportsAudioOutput
         case .azureOpenAI:
             false // Azure chat endpoints currently omit audio output
@@ -1040,6 +1085,8 @@ extension LanguageModel {
             model.supportsTools
         case let .minimaxCN(model):
             model.supportsTools
+        case let .kimi(model):
+            model.supportsTools
         case .azureOpenAI:
             true // Azure OpenAI mirrors OpenAI tool support
         case .openRouter, .together, .replicate:
@@ -1072,6 +1119,8 @@ extension LanguageModel {
         case let .minimax(model):
             model.contextLength
         case let .minimaxCN(model):
+            model.contextLength
+        case let .kimi(model):
             model.contextLength
         case .azureOpenAI:
             128_000 // conservative default matching OpenAI tier
@@ -1124,6 +1173,9 @@ extension LanguageModel {
         case let .minimaxCN(model):
             hasher.combine("minimax-cn")
             hasher.combine(model)
+        case let .kimi(model):
+            hasher.combine("kimi")
+            hasher.combine(model)
         case let .openRouter(modelId):
             hasher.combine("openRouter")
             hasher.combine(modelId)
@@ -1175,6 +1227,8 @@ extension LanguageModel {
         case let (.minimax(lhsModel), .minimax(rhsModel)):
             lhsModel == rhsModel
         case let (.minimaxCN(lhsModel), .minimaxCN(rhsModel)):
+            lhsModel == rhsModel
+        case let (.kimi(lhsModel), .kimi(rhsModel)):
             lhsModel == rhsModel
         case let (.openRouter(lhsId), .openRouter(rhsId)):
             lhsId == rhsId
@@ -1252,6 +1306,13 @@ extension LanguageModel {
             ["minimax-cn", "minimax_cn", "minimaxi"].contains(qualified.provider.lowercased())
         {
             return Self.parseMiniMaxModelIdentifier(qualified.model).map(LanguageModel.minimaxCN)
+        }
+
+        if
+            let qualified,
+            ["kimi", "moonshot"].contains(qualified.provider.lowercased())
+        {
+            return Self.parseKimiModelIdentifier(qualified.model).map(LanguageModel.kimi)
         }
 
         if let qualified {
@@ -1559,6 +1620,34 @@ extension LanguageModel {
             return .minimax(.m27)
         }
 
+        // MARK: Kimi (Moonshot) models
+
+        if
+            dashed.contains("kimi-k2.7") ||
+            dotted.contains("kimi-k2-7") ||
+            compact.contains("kimik27") ||
+            compact.contains("k2p7") ||
+            dashed == "k2p7" ||
+            dashed == "k2.7" ||
+            dotted == "k2-7"
+        {
+            return .kimi(.k27)
+        }
+
+        if
+            dashed.contains("kimi-k2.6") ||
+            dotted.contains("kimi-k2-6") ||
+            compact.contains("kimik26") ||
+            compact.contains("k2p6") ||
+            dashed == "k2p6" ||
+            dashed == "k2.6" ||
+            dotted == "k2-6" ||
+            normalized == "kimi" ||
+            normalized == "moonshot"
+        {
+            return .kimi(.k26)
+        }
+
         // MARK: Grok models
 
         let unsupportedGrok = normalized.contains("grok-4.20-multi-agent") ||
@@ -1793,6 +1882,19 @@ extension LanguageModel {
             return .m27
         case "minimax-m2.7-highspeed", "minimax-m2-7-highspeed", "m2.7-highspeed", "m2-7-highspeed":
             return .m27Highspeed
+        default:
+            return nil
+        }
+    }
+
+    private static func parseKimiModelIdentifier(_ modelString: String) -> Kimi? {
+        let normalized = modelString.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        switch normalized {
+        case "k2p6", "kimi-k2.6", "kimi-k2-6", "kimi-k2p6", "kimi-k2.6-code", "k2.6":
+            return .k26
+        case "k2p7", "kimi-k2.7", "kimi-k2-7", "kimi-k2p7", "kimi-k2p7-code", "kimi-k2.7-code", "k2.7", "kimi-k2.7-code-free":
+            return .k27
         default:
             return nil
         }

--- a/Sources/Tachikoma/Models/ModelSelection.swift
+++ b/Sources/Tachikoma/Models/ModelSelection.swift
@@ -39,6 +39,10 @@ public struct ModelSelector {
             return .minimax(miniMaxModel)
         }
 
+        if let kimiModel = parseKimiModel(normalized) {
+            return .kimi(kimiModel)
+        }
+
         // Grok shortcuts and models
         if let grokModel = parseGrokModel(normalized) {
             return .grok(grokModel)
@@ -307,6 +311,22 @@ public struct ModelSelector {
         }
     }
 
+    private static func parseKimiModel(_ input: String) -> Model.Kimi? {
+        switch input {
+        case "kimi-k2.7-code-highspeed", "kimi-k2-7-code-highspeed", "k2.7-code-highspeed", "k2-7-code-highspeed",
+             "kimi/kimi-k2.7-code-highspeed", "moonshot/kimi-k2.7-code-highspeed":
+            .k27CodeHighspeed
+        case "kimi-k2.7-code", "kimi-k2-7-code", "k2.7-code", "k2-7-code", "kimi/kimi-k2.7-code",
+             "moonshot/kimi-k2.7-code":
+            .k27Code
+        case "kimi-k2.6", "kimi-k2-6", "k2.6", "k2-6", "kimi/kimi-k2.6", "moonshot/kimi-k2.6",
+             "kimi", "moonshot":
+            .k26
+        default:
+            nil
+        }
+    }
+
     private static func isUnsupportedLegacyGrokModel(_ input: String) -> Bool {
         let normalized = input.lowercased()
         return normalized.contains("grok-4.20-multi-agent") ||
@@ -418,6 +438,8 @@ public struct ModelSelector {
             return Model.Google.allCases.map(\.userFacingModelId)
         case "minimax", "minimax-cn", "minimaxi":
             return Model.MiniMax.allCases.map(\.modelId)
+        case "kimi", "moonshot":
+            return Model.Kimi.allCases.map(\.modelId)
         case "ollama":
             return Model.Ollama.allCases.compactMap {
                 if case .custom = $0 { return nil }
@@ -509,6 +531,11 @@ public func getAllAvailableModels() -> String {
     )
 
     output += formatModelList(
+        title: "Kimi (Moonshot AI)",
+        models: ModelSelector.availableModels(for: "kimi"),
+    )
+
+    output += formatModelList(
         title: "Grok (xAI)",
         models: ModelSelector.availableModels(for: "grok"),
     )
@@ -525,6 +552,7 @@ public func getAllAvailableModels() -> String {
     output += "  • gemini → gemini-3.5-flash\n"
     output += "  • minimax → MiniMax-M2.7\n"
     output += "  • minimax-cn → MiniMax-M2.7 via api.minimaxi.com\n"
+    output += "  • kimi, moonshot → kimi-k2.6\n"
     output += "  • grok → grok-4.3\n"
     output += "  • llama, llama3 → llama3.3\n"
 

--- a/Sources/Tachikoma/Providers/Compatible/OpenAICompatibleProvider.swift
+++ b/Sources/Tachikoma/Providers/Compatible/OpenAICompatibleProvider.swift
@@ -19,6 +19,7 @@ public final class OpenAICompatibleProvider: ModelProvider {
         configuration: TachikomaConfiguration,
         apiKey: String? = nil,
         additionalHeaders: [String: String] = [:],
+        capabilities: ModelCapabilities? = nil,
         session: URLSession = .shared,
     ) throws {
         self.modelId = modelId
@@ -41,7 +42,7 @@ public final class OpenAICompatibleProvider: ModelProvider {
         }
 
         let isFable = LanguageModel.Anthropic.isFable(modelId: modelId)
-        self.capabilities = ModelCapabilities(
+        self.capabilities = capabilities ?? ModelCapabilities(
             supportsVision: false,
             supportsTools: true,
             supportsStreaming: !LanguageModel.Anthropic.hasStreamingRefusalRisk(modelId: modelId),

--- a/Sources/Tachikoma/Providers/Compatible/OpenAICompatibleProvider.swift
+++ b/Sources/Tachikoma/Providers/Compatible/OpenAICompatibleProvider.swift
@@ -19,7 +19,6 @@ public final class OpenAICompatibleProvider: ModelProvider {
         configuration: TachikomaConfiguration,
         apiKey: String? = nil,
         additionalHeaders: [String: String] = [:],
-        capabilities: ModelCapabilities? = nil,
         session: URLSession = .shared,
     ) throws {
         self.modelId = modelId
@@ -42,7 +41,7 @@ public final class OpenAICompatibleProvider: ModelProvider {
         }
 
         let isFable = LanguageModel.Anthropic.isFable(modelId: modelId)
-        self.capabilities = capabilities ?? ModelCapabilities(
+        self.capabilities = ModelCapabilities(
             supportsVision: false,
             supportsTools: true,
             supportsStreaming: !LanguageModel.Anthropic.hasStreamingRefusalRisk(modelId: modelId),

--- a/Sources/Tachikoma/Providers/Kimi/KimiProvider.swift
+++ b/Sources/Tachikoma/Providers/Kimi/KimiProvider.swift
@@ -1,0 +1,59 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Provider for Kimi models hosted by Moonshot AI.
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public final class KimiProvider: ModelProvider {
+    public let modelId: String
+    public let baseURL: String?
+    public let apiKey: String?
+    public let capabilities: ModelCapabilities
+
+    private let session: URLSession
+
+    public init(
+        model: LanguageModel.Kimi,
+        configuration: TachikomaConfiguration,
+        session: URLSession = .shared,
+    ) throws {
+        self.modelId = model.modelId
+        self.baseURL = configuration.getBaseURL(for: .kimi) ?? Provider.kimi.defaultBaseURL
+        self.session = session
+
+        guard let apiKey = configuration.getAPIKey(for: .kimi) else {
+            throw TachikomaError.authenticationFailed("MOONSHOT_API_KEY not found")
+        }
+        self.apiKey = apiKey
+        self.capabilities = ModelCapabilities(
+            supportsVision: model.supportsVision,
+            supportsTools: model.supportsTools,
+            supportsStreaming: true,
+            contextLength: model.contextLength,
+            maxOutputTokens: 32768,
+        )
+    }
+
+    public func generateText(request: ProviderRequest) async throws -> ProviderResponse {
+        try await OpenAICompatibleHelper.generateText(
+            request: request,
+            modelId: self.modelId,
+            baseURL: self.baseURL!,
+            apiKey: self.apiKey!,
+            providerName: "Kimi",
+            session: self.session,
+        )
+    }
+
+    public func streamText(request: ProviderRequest) async throws -> AsyncThrowingStream<TextStreamDelta, Error> {
+        try await OpenAICompatibleHelper.streamText(
+            request: request,
+            modelId: self.modelId,
+            baseURL: self.baseURL!,
+            apiKey: self.apiKey!,
+            providerName: "Kimi",
+            session: self.session,
+        )
+    }
+}

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAITypes.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAITypes.swift
@@ -79,12 +79,14 @@ struct OpenAIChatMessage: Codable {
     let toolCalls: [AgentToolCall]?
     let reasoning: String?
     let reasoningDetails: [JSONValue]?
+    let reasoningContent: String?
 
     enum CodingKeys: String, CodingKey {
         case role, content, reasoning
         case toolCallId = "tool_call_id"
         case toolCalls = "tool_calls"
         case reasoningDetails = "reasoning_details"
+        case reasoningContent = "reasoning_content"
     }
 
     struct AgentToolCall: Codable {
@@ -105,6 +107,7 @@ struct OpenAIChatMessage: Codable {
         self.toolCalls = nil
         self.reasoning = nil
         self.reasoningDetails = nil
+        self.reasoningContent = nil
     }
 
     init(role: String, content: [OpenAIChatMessageContent], toolCallId: String? = nil) {
@@ -114,6 +117,7 @@ struct OpenAIChatMessage: Codable {
         self.toolCalls = nil
         self.reasoning = nil
         self.reasoningDetails = nil
+        self.reasoningContent = nil
     }
 
     init(
@@ -122,6 +126,7 @@ struct OpenAIChatMessage: Codable {
         toolCalls: [AgentToolCall]?,
         reasoning: String? = nil,
         reasoningDetails: [JSONValue]? = nil,
+        reasoningContent: String? = nil,
     ) {
         self.role = role
         self.content = content.map { .left($0) }
@@ -129,6 +134,7 @@ struct OpenAIChatMessage: Codable {
         self.toolCalls = toolCalls
         self.reasoning = reasoning
         self.reasoningDetails = reasoningDetails
+        self.reasoningContent = reasoningContent
     }
 }
 
@@ -263,11 +269,13 @@ struct OpenAIChatResponse: Codable {
         let toolCalls: [AgentToolCall]?
         let reasoning: String?
         let reasoningDetails: [JSONValue]?
+        let reasoningContent: String?
 
         enum CodingKeys: String, CodingKey {
             case role, content, reasoning
             case toolCalls = "tool_calls"
             case reasoningDetails = "reasoning_details"
+            case reasoningContent = "reasoning_content"
         }
     }
 
@@ -313,10 +321,12 @@ struct OpenAIStreamChunk: Codable {
     struct Delta: Codable {
         let role: String?
         let content: String?
+        let reasoningContent: String?
         let toolCalls: [ToolCall]?
 
         enum CodingKeys: String, CodingKey {
             case role, content
+            case reasoningContent = "reasoning_content"
             case toolCalls = "tool_calls"
         }
 

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAITypes.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAITypes.swift
@@ -10,9 +10,10 @@ struct OpenAIChatRequest: Codable {
     let tools: [OpenAITool]?
     let stream: Bool?
     let stop: [String]? // Native stop sequences support
+    let thinking: OpenAIThinkingConfiguration?
 
     enum CodingKeys: String, CodingKey {
-        case model, messages, temperature, tools, stream, stop
+        case model, messages, temperature, tools, stream, stop, thinking
         case maxTokens = "max_tokens"
         case maxCompletionTokens = "max_completion_tokens"
     }
@@ -25,6 +26,7 @@ struct OpenAIChatRequest: Codable {
         tools: [OpenAITool]? = nil,
         stream: Bool? = nil,
         stop: [String]? = nil,
+        thinking: OpenAIThinkingConfiguration? = nil,
     ) {
         self.model = model
         self.messages = messages
@@ -33,6 +35,7 @@ struct OpenAIChatRequest: Codable {
         self.tools = tools
         self.stream = stream
         self.stop = stop
+        self.thinking = thinking
     }
 
     init(from decoder: Decoder) throws {
@@ -51,6 +54,7 @@ struct OpenAIChatRequest: Codable {
         self.tools = try container.decodeIfPresent([OpenAITool].self, forKey: .tools)
         self.stream = try container.decodeIfPresent(Bool.self, forKey: .stream)
         self.stop = try container.decodeIfPresent([String].self, forKey: .stop)
+        self.thinking = try container.decodeIfPresent(OpenAIThinkingConfiguration.self, forKey: .thinking)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -69,7 +73,13 @@ struct OpenAIChatRequest: Codable {
         try container.encodeIfPresent(self.tools, forKey: .tools)
         try container.encodeIfPresent(self.stream, forKey: .stream)
         try container.encodeIfPresent(self.stop, forKey: .stop)
+        try container.encodeIfPresent(self.thinking, forKey: .thinking)
     }
+}
+
+struct OpenAIThinkingConfiguration: Codable {
+    let type: String
+    let keep: String?
 }
 
 struct OpenAIChatMessage: Codable {

--- a/Sources/Tachikoma/Providers/ProviderFactory.swift
+++ b/Sources/Tachikoma/Providers/ProviderFactory.swift
@@ -81,23 +81,7 @@ public struct ProviderFactory {
             )
 
         case let .kimi(kimiModel):
-            guard let apiKey = configuration.getAPIKey(for: .kimi) else {
-                throw TachikomaError.authenticationFailed("MOONSHOT_API_KEY not found")
-            }
-            let baseURL = configuration.getBaseURL(for: .kimi) ?? Provider.kimi.defaultBaseURL ?? "https://api.kimi.com/coding/v1"
-            return try OpenAICompatibleProvider(
-                modelId: kimiModel.modelId,
-                baseURL: baseURL,
-                configuration: configuration,
-                apiKey: apiKey,
-                capabilities: ModelCapabilities(
-                    supportsVision: kimiModel.supportsVision,
-                    supportsTools: kimiModel.supportsTools,
-                    supportsStreaming: true,
-                    contextLength: kimiModel.contextLength,
-                    maxOutputTokens: 32_768,
-                ),
-            )
+            return try KimiProvider(model: kimiModel, configuration: configuration)
 
         case let .openRouter(modelId):
             return try OpenRouterProvider(modelId: modelId, configuration: configuration)

--- a/Sources/Tachikoma/Providers/ProviderFactory.swift
+++ b/Sources/Tachikoma/Providers/ProviderFactory.swift
@@ -80,6 +80,25 @@ public struct ProviderFactory {
                 configuration: configuration,
             )
 
+        case let .kimi(kimiModel):
+            guard let apiKey = configuration.getAPIKey(for: .kimi) else {
+                throw TachikomaError.authenticationFailed("MOONSHOT_API_KEY not found")
+            }
+            let baseURL = configuration.getBaseURL(for: .kimi) ?? Provider.kimi.defaultBaseURL ?? "https://api.kimi.com/coding/v1"
+            return try OpenAICompatibleProvider(
+                modelId: kimiModel.modelId,
+                baseURL: baseURL,
+                configuration: configuration,
+                apiKey: apiKey,
+                capabilities: ModelCapabilities(
+                    supportsVision: kimiModel.supportsVision,
+                    supportsTools: kimiModel.supportsTools,
+                    supportsStreaming: true,
+                    contextLength: kimiModel.contextLength,
+                    maxOutputTokens: 32_768,
+                ),
+            )
+
         case let .openRouter(modelId):
             return try OpenRouterProvider(modelId: modelId, configuration: configuration)
 

--- a/Sources/Tachikoma/Providers/ProviderParser.swift
+++ b/Sources/Tachikoma/Providers/ProviderParser.swift
@@ -96,6 +96,7 @@ public enum ProviderParser {
     ///   - hasGrok: Whether Grok API key is available
     ///   - hasGoogle: Whether Google/Gemini API key is available
     ///   - hasMiniMax: Whether MiniMax API key is available
+    ///   - hasKimi: Whether Moonshot/Kimi API key is available
     ///   - hasOllama: Whether Ollama is available (always true as it doesn't require API key)
     ///   - configuredDefault: Optional default from configuration
     ///   - isEnvironmentProvided: Whether the providers string came from environment variable
@@ -107,6 +108,7 @@ public enum ProviderParser {
         hasGrok: Bool = false,
         hasGoogle: Bool? = nil,
         hasMiniMax: Bool = false,
+        hasKimi: Bool = false,
         hasOllama: Bool = true,
         configuredDefault: LanguageModel? = nil,
         isEnvironmentProvided: Bool = false,
@@ -132,6 +134,8 @@ public enum ProviderParser {
                 environmentModel = self.parseMiniMaxModel(config.model)
             case "minimax-cn" where hasMiniMax, "minimax_cn" where hasMiniMax, "minimaxi" where hasMiniMax:
                 environmentModel = self.parseMiniMaxCNModel(config.model)
+            case "kimi" where hasKimi, "moonshot" where hasKimi:
+                environmentModel = self.parseKimiModel(config.model)
             case "grok" where hasGrok, "xai" where hasGrok:
                 environmentModel = self.parseGrokModel(config.model)
             case "ollama" where hasOllama:
@@ -164,6 +168,7 @@ public enum ProviderParser {
                 hasGrok: hasGrok,
                 hasGoogle: canFallbackToGoogle,
                 hasMiniMax: hasMiniMax,
+                hasKimi: hasKimi,
                 hasOllama: hasOllama,
             )
         }
@@ -184,6 +189,7 @@ public enum ProviderParser {
         hasGrok: Bool = false,
         hasGoogle: Bool? = nil,
         hasMiniMax: Bool = false,
+        hasKimi: Bool = false,
         hasOllama: Bool = true,
         configuredDefault: LanguageModel? = nil,
     )
@@ -197,6 +203,7 @@ public enum ProviderParser {
             hasGrok: hasGrok,
             hasGoogle: hasGoogle,
             hasMiniMax: hasMiniMax,
+            hasKimi: hasKimi,
             hasOllama: hasOllama,
             configuredDefault: configuredDefault,
             isEnvironmentProvided: false,
@@ -337,6 +344,19 @@ public enum ProviderParser {
         }
     }
 
+    private static func parseKimiModel(_ modelString: String) -> LanguageModel? {
+        switch modelString.lowercased() {
+        case "kimi-k2.7-code-highspeed", "kimi-k2-7-code-highspeed", "k2.7-code-highspeed", "k2-7-code-highspeed":
+            .kimi(.k27CodeHighspeed)
+        case "kimi-k2.7-code", "kimi-k2-7-code", "k2.7-code", "k2-7-code":
+            .kimi(.k27Code)
+        case "kimi-k2.6", "kimi-k2-6", "k2.6", "k2-6":
+            .kimi(.k26)
+        default:
+            nil
+        }
+    }
+
     private static func parseGrokModel(_ modelString: String) -> LanguageModel? {
         switch modelString.lowercased() {
         case "grok-4.3", "grok-4-3", "grok43", "grok-4.3-latest", "grok-4-latest", "grok-4", "grok-latest":
@@ -386,6 +406,7 @@ public enum ProviderParser {
         hasGrok: Bool,
         hasGoogle: Bool,
         hasMiniMax: Bool,
+        hasKimi: Bool,
         hasOllama _: Bool,
     )
         -> LanguageModel
@@ -400,6 +421,8 @@ public enum ProviderParser {
             .google(.gemini35Flash)
         } else if hasMiniMax {
             .minimax(.m27)
+        } else if hasKimi {
+            .kimi(.k26)
         } else {
             .ollama(.llama33)
         }

--- a/Sources/Tachikoma/Utilities/UsageTracking.swift
+++ b/Sources/Tachikoma/Utilities/UsageTracking.swift
@@ -575,10 +575,9 @@ public struct ModelCostCalculator: Sendable {
             }
         case .minimax, .minimaxCN: (0.30, 1.20)
         case let .kimi(kimiModel):
-            // Approximate USD equivalents of Moonshot's published CNY prices.
             switch kimiModel {
-            case .k27CodeHighspeed: (1.80, 7.50)
-            case .k27Code, .k26: (0.90, 3.75)
+            case .k27CodeHighspeed: (1.90, 8.00)
+            case .k27Code, .k26: (0.95, 4.00)
             }
         case .ollama: (0.00, 0.00) // Local inference
         case .lmstudio: (0.00, 0.00) // Local inference

--- a/Sources/Tachikoma/Utilities/UsageTracking.swift
+++ b/Sources/Tachikoma/Utilities/UsageTracking.swift
@@ -574,7 +574,12 @@ public struct ModelCostCalculator: Sendable {
             case .custom: (2.00, 8.00)
             }
         case .minimax, .minimaxCN: (0.30, 1.20)
-        case .kimi: (0.60, 2.40) // Estimate; verify against Moonshot/Kimi pricing
+        case let .kimi(kimiModel):
+            // Approximate USD equivalents of Moonshot's published CNY prices.
+            switch kimiModel {
+            case .k27CodeHighspeed: (1.80, 7.50)
+            case .k27Code, .k26: (0.90, 3.75)
+            }
         case .ollama: (0.00, 0.00) // Local inference
         case .lmstudio: (0.00, 0.00) // Local inference
         case .openRouter, .together, .replicate: (1.00, 3.00) // Typical aggregator pricing

--- a/Sources/Tachikoma/Utilities/UsageTracking.swift
+++ b/Sources/Tachikoma/Utilities/UsageTracking.swift
@@ -574,6 +574,7 @@ public struct ModelCostCalculator: Sendable {
             case .custom: (2.00, 8.00)
             }
         case .minimax, .minimaxCN: (0.30, 1.20)
+        case .kimi: (0.60, 2.40) // Estimate; verify against Moonshot/Kimi pricing
         case .ollama: (0.00, 0.00) // Local inference
         case .lmstudio: (0.00, 0.00) // Local inference
         case .openRouter, .together, .replicate: (1.00, 3.00) // Typical aggregator pricing

--- a/Tests/TachikomaTests/Core/GenerationTests.swift
+++ b/Tests/TachikomaTests/Core/GenerationTests.swift
@@ -1907,6 +1907,36 @@ struct GenerationTests {
         #expect(thinking.metadata?.customData?["openrouter.reasoning_details"]?.contains("sealed") == true)
     }
 
+    @Test
+    func `GenerateText tags Kimi reasoning with configured endpoint`() async throws {
+        let config = TachikomaConfiguration(loadFromEnvironment: false)
+        config.setBaseURL("https://kimi-proxy.example.test/v1?tenant=a", for: .kimi)
+        config.setProviderFactoryOverride { _, _ in
+            StaticProvider(response: ProviderResponse(
+                text: "",
+                finishReason: .toolCalls,
+                toolCalls: [AgentToolCall(id: "call-1", name: "lookup", arguments: [:])],
+                reasoning: [ProviderReasoningBlock(
+                    text: "native Kimi thought",
+                    type: "kimi_reasoning_content",
+                )],
+            ))
+        }
+
+        let result = try await generateText(
+            model: .kimi(.k27Code),
+            messages: [.user("hi")],
+            configuration: config,
+        )
+
+        let thinking = try #require(result.messages.first { $0.channel == .thinking })
+        #expect(thinking.metadata?.customData?["kimi.reasoning_content"] == "native Kimi thought")
+        #expect(thinking.metadata?.customData?["tachikoma.reasoning.provider"] == "kimi")
+        #expect(thinking.metadata?.customData?["tachikoma.reasoning.model"] == "kimi-k2.7-code")
+        #expect(thinking.metadata?.customData?["tachikoma.reasoning.base_url"] == ReasoningEndpointIdentity
+            .canonical("https://kimi-proxy.example.test/v1?tenant=a"))
+    }
+
     // MARK: - Image Input Type Tests
 
     @Test

--- a/Tests/TachikomaTests/Core/GenerationTests.swift
+++ b/Tests/TachikomaTests/Core/GenerationTests.swift
@@ -1916,10 +1916,12 @@ struct GenerationTests {
                 text: "",
                 finishReason: .toolCalls,
                 toolCalls: [AgentToolCall(id: "call-1", name: "lookup", arguments: [:])],
-                reasoning: [ProviderReasoningBlock(
-                    text: "native Kimi thought",
-                    type: "kimi_reasoning_content",
-                )],
+                reasoning: [
+                    ProviderReasoningBlock(
+                        text: "native Kimi thought",
+                        type: "kimi_reasoning_content",
+                    ),
+                ],
             ))
         }
 

--- a/Tests/TachikomaTests/Core/LanguageModelCoverageTests.swift
+++ b/Tests/TachikomaTests/Core/LanguageModelCoverageTests.swift
@@ -60,6 +60,13 @@ struct LanguageModelCoverageTests {
             #expect(model.contextLength > 0)
         }
 
+        for model in LanguageModel.Kimi.allCases {
+            #expect(!model.modelId.isEmpty)
+            _ = model.supportsVision
+            _ = model.supportsTools
+            #expect(model.contextLength == 262_144)
+        }
+
         for model in LanguageModel.Ollama.allCases {
             #expect(!model.modelId.isEmpty)
             _ = model.supportsVision
@@ -85,7 +92,8 @@ struct LanguageModelCoverageTests {
             .minimax(.m27),
             .minimaxCN(.m27),
             .kimi(.k26),
-            .kimi(.k27),
+            .kimi(.k27Code),
+            .kimi(.k27CodeHighspeed),
             .ollama(.llama33),
             .lmstudio(.gptOSS20B),
             .openRouter(modelId: "openrouter/alpha"),

--- a/Tests/TachikomaTests/Core/LanguageModelCoverageTests.swift
+++ b/Tests/TachikomaTests/Core/LanguageModelCoverageTests.swift
@@ -84,6 +84,8 @@ struct LanguageModelCoverageTests {
             .grok(.grok43),
             .minimax(.m27),
             .minimaxCN(.m27),
+            .kimi(.k26),
+            .kimi(.k27),
             .ollama(.llama33),
             .lmstudio(.gptOSS20B),
             .openRouter(modelId: "openrouter/alpha"),

--- a/Tests/TachikomaTests/Core/ModelParsingTests.swift
+++ b/Tests/TachikomaTests/Core/ModelParsingTests.swift
@@ -131,6 +131,25 @@ struct ModelParsingTests {
     }
 
     @Test
+    func `parse Kimi (Moonshot) model ids`() throws {
+        #expect(LanguageModel.parse(from: "kimi/k2p6") == .kimi(.k26))
+        #expect(LanguageModel.parse(from: "kimi/MiniMax-K2.6") == nil)
+        #expect(LanguageModel.parse(from: "kimi/kimi-k2.6") == .kimi(.k26))
+        #expect(LanguageModel.parse(from: "kimi/k2p7") == .kimi(.k27))
+        #expect(LanguageModel.parse(from: "kimi/kimi-k2.7-code") == .kimi(.k27))
+        #expect(LanguageModel.parse(from: "moonshot/k2p7") == .kimi(.k27))
+        #expect(LanguageModel.parse(from: "kimi-k2.6") == .kimi(.k26))
+        #expect(LanguageModel.parse(from: "kimi-k2.7") == .kimi(.k27))
+        #expect(LanguageModel.parse(from: "k2p6") == .kimi(.k26))
+        #expect(LanguageModel.parse(from: "k2p7") == .kimi(.k27))
+        #expect(LanguageModel.parse(from: "kimi") == .kimi(.k26))
+        #expect(LanguageModel.Kimi.k26.supportsVision == true)
+        #expect(LanguageModel.Kimi.k27.supportsVision == true)
+        #expect(LanguageModel.Kimi.k27.modelId == "k2p7")
+        #expect(LanguageModel.Kimi.k27.contextLength == 262_144)
+    }
+
+    @Test
     func `parse OpenRouter model ids`() throws {
         #expect(LanguageModel
             .parse(from: "openrouter/xiaomi/mimo-v2.5-pro") == .openRouter(modelId: "xiaomi/mimo-v2.5-pro"))

--- a/Tests/TachikomaTests/Core/ModelParsingTests.swift
+++ b/Tests/TachikomaTests/Core/ModelParsingTests.swift
@@ -132,21 +132,25 @@ struct ModelParsingTests {
 
     @Test
     func `parse Kimi (Moonshot) model ids`() throws {
-        #expect(LanguageModel.parse(from: "kimi/k2p6") == .kimi(.k26))
         #expect(LanguageModel.parse(from: "kimi/MiniMax-K2.6") == nil)
         #expect(LanguageModel.parse(from: "kimi/kimi-k2.6") == .kimi(.k26))
-        #expect(LanguageModel.parse(from: "kimi/k2p7") == .kimi(.k27))
-        #expect(LanguageModel.parse(from: "kimi/kimi-k2.7-code") == .kimi(.k27))
-        #expect(LanguageModel.parse(from: "moonshot/k2p7") == .kimi(.k27))
+        #expect(LanguageModel.parse(from: "kimi/kimi-k2.7-code") == .kimi(.k27Code))
+        #expect(LanguageModel.parse(from: "moonshot/kimi-k2.7-code") == .kimi(.k27Code))
+        #expect(LanguageModel.parse(from: "kimi/kimi-k2.7-code-highspeed") == .kimi(.k27CodeHighspeed))
         #expect(LanguageModel.parse(from: "kimi-k2.6") == .kimi(.k26))
-        #expect(LanguageModel.parse(from: "kimi-k2.7") == .kimi(.k27))
-        #expect(LanguageModel.parse(from: "k2p6") == .kimi(.k26))
-        #expect(LanguageModel.parse(from: "k2p7") == .kimi(.k27))
+        #expect(LanguageModel.parse(from: "kimi-k2.7-code") == .kimi(.k27Code))
         #expect(LanguageModel.parse(from: "kimi") == .kimi(.k26))
+        #expect(try ModelSelector.parseModel("kimi/kimi-k2.6") == .kimi(.k26))
+        #expect(try ModelSelector.parseModel("moonshot/kimi-k2.7-code") == .kimi(.k27Code))
         #expect(LanguageModel.Kimi.k26.supportsVision == true)
-        #expect(LanguageModel.Kimi.k27.supportsVision == true)
-        #expect(LanguageModel.Kimi.k27.modelId == "k2p7")
-        #expect(LanguageModel.Kimi.k27.contextLength == 262_144)
+        #expect(LanguageModel.Kimi.k27Code.supportsVision == true)
+        #expect(LanguageModel.Kimi.k27Code.modelId == "kimi-k2.7-code")
+        #expect(LanguageModel.Kimi.k27CodeHighspeed.contextLength == 262_144)
+        #expect(ModelSelector.availableModels(for: "moonshot") == [
+            "kimi-k2.7-code",
+            "kimi-k2.7-code-highspeed",
+            "kimi-k2.6",
+        ])
     }
 
     @Test
@@ -229,6 +233,22 @@ struct ModelParsingTests {
                 )
 
                 #expect(model == .minimaxCN(.m27))
+            }
+        }
+    }
+
+    @Test
+    func `ProviderParser accepts Kimi provider aliases`() {
+        if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+            for provider in ["kimi", "moonshot"] {
+                let model = ProviderParser.determineDefaultModel(
+                    from: "\(provider)/kimi-k2.7-code",
+                    hasOpenAI: false,
+                    hasAnthropic: false,
+                    hasKimi: true,
+                )
+
+                #expect(model == .kimi(.k27Code))
             }
         }
     }

--- a/Tests/TachikomaTests/Core/OpenAICompatibleHelperTests.swift
+++ b/Tests/TachikomaTests/Core/OpenAICompatibleHelperTests.swift
@@ -368,6 +368,51 @@ struct OpenAICompatibleHelperTests {
         let assistant = try #require(messages.first { $0["role"] as? String == "assistant" })
         #expect(assistant["reasoning_content"] as? String == "native Kimi thought")
         #expect(assistant["tool_calls"] != nil)
+        #expect(bodyJSON["thinking"] == nil)
+    }
+
+    @Test
+    func `generateText enables preserved thinking when replaying Kimi K2_6 reasoning`() async throws {
+        let capture = CapturedRequest()
+        let endpoint = "https://api.moonshot.cn/v1"
+        let request = try ProviderRequest(messages: [
+            .user("first"),
+            ModelMessage(
+                role: .assistant,
+                content: [.text("native Kimi thought")],
+                channel: .thinking,
+                metadata: .init(customData: [
+                    "kimi.reasoning_content": "native Kimi thought",
+                    "tachikoma.reasoning.provider": "kimi",
+                    "tachikoma.reasoning.model": "kimi-k2.6",
+                    "tachikoma.reasoning.base_url": #require(ReasoningEndpointIdentity.canonical(endpoint)),
+                ]),
+            ),
+            .assistant("answer"),
+            .user("continue"),
+        ])
+
+        _ = try await self.withMockedSession { urlRequest in
+            capture.body = self.bodyData(from: urlRequest)
+            return self.jsonResponse(for: urlRequest, data: Self.chatCompletionPayload(text: "done"))
+        } operation: { session in
+            try await OpenAICompatibleHelper.generateText(
+                request: request,
+                modelId: "kimi-k2.6",
+                baseURL: endpoint,
+                apiKey: "sk-test",
+                providerName: "Kimi",
+                session: session,
+            )
+        }
+
+        let bodyJSON = try #require(capture.body).jsonObject()
+        let thinking = try #require(bodyJSON["thinking"] as? [String: String])
+        #expect(thinking["type"] == "enabled")
+        #expect(thinking["keep"] == "all")
+        let messages = try #require(bodyJSON["messages"] as? [[String: Any]])
+        let assistant = try #require(messages.first { $0["role"] as? String == "assistant" })
+        #expect(assistant["reasoning_content"] as? String == "native Kimi thought")
     }
 
     @Test

--- a/Tests/TachikomaTests/Core/OpenAICompatibleHelperTests.swift
+++ b/Tests/TachikomaTests/Core/OpenAICompatibleHelperTests.swift
@@ -287,20 +287,24 @@ struct OpenAICompatibleHelperTests {
         let response = try await self.withMockedSession { urlRequest in
             let payload: [String: Any] = [
                 "id": "chatcmpl-kimi",
-                "choices": [[
-                    "index": 0,
-                    "message": [
-                        "role": "assistant",
-                        "content": NSNull(),
-                        "reasoning_content": "native Kimi thought",
-                        "tool_calls": [[
-                            "id": "call-1",
-                            "type": "function",
-                            "function": ["name": "lookup", "arguments": "{}"],
-                        ]],
+                "choices": [
+                    [
+                        "index": 0,
+                        "message": [
+                            "role": "assistant",
+                            "content": NSNull(),
+                            "reasoning_content": "native Kimi thought",
+                            "tool_calls": [
+                                [
+                                    "id": "call-1",
+                                    "type": "function",
+                                    "function": ["name": "lookup", "arguments": "{}"],
+                                ],
+                            ],
+                        ],
+                        "finish_reason": "tool_calls",
                     ],
-                    "finish_reason": "tool_calls",
-                ]],
+                ],
             ]
             return try self.jsonResponse(for: urlRequest, data: JSONSerialization.data(withJSONObject: payload))
         } operation: { session in

--- a/Tests/TachikomaTests/Core/OpenAICompatibleHelperTests.swift
+++ b/Tests/TachikomaTests/Core/OpenAICompatibleHelperTests.swift
@@ -165,6 +165,51 @@ struct OpenAICompatibleHelperTests {
     }
 
     @Test
+    func `streamText emits Kimi reasoning content`() async throws {
+        let request = ProviderRequest(messages: [.user("stream")])
+
+        let deltas = try await self.withMockedSession { urlRequest in
+            let sse = """
+            data: {"id":"chunk_1","choices":[{"delta":{"reasoning_content":"thinking"},"index":0,"finish_reason":null}]}
+
+            data: {"id":"chunk_2","choices":[{"delta":{"content":"answer"},"index":0,"finish_reason":null}]}
+
+            data: {"id":"chunk_3","choices":[{"delta":{},"index":0,"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """.utf8Data()
+            let response = HTTPURLResponse(
+                url: urlRequest.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/event-stream"],
+            )!
+            return (response, sse)
+        } operation: { session in
+            let stream = try await OpenAICompatibleHelper.streamText(
+                request: request,
+                modelId: "kimi-k2.7-code",
+                baseURL: "https://api.moonshot.cn/v1",
+                apiKey: "sk-test",
+                providerName: "Kimi",
+                session: session,
+            )
+
+            var deltas: [TextStreamDelta] = []
+            for try await delta in stream {
+                deltas.append(delta)
+            }
+            return deltas
+        }
+
+        #expect(deltas.contains {
+            $0.type == .reasoning && $0.content == "thinking" && $0.reasoningType == "kimi_reasoning_content"
+        })
+        #expect(deltas.contains { $0.type == .textDelta && $0.content == "answer" })
+    }
+
+    @Test
     func `OpenAI-compatible provider forwards configured headers`() async throws {
         let request = ProviderRequest(
             messages: [ModelMessage(role: .user, content: [.text("ping")])],
@@ -235,6 +280,90 @@ struct OpenAICompatibleHelperTests {
         #expect(reasoning.type == "openrouter_reasoning_details")
         #expect(reasoning.rawJSON?.contains("reasoning.encrypted") == true)
         #expect(response.toolCalls?.first?.id == "call-1")
+    }
+
+    @Test
+    func `generateText decodes Kimi reasoning content`() async throws {
+        let response = try await self.withMockedSession { urlRequest in
+            let payload: [String: Any] = [
+                "id": "chatcmpl-kimi",
+                "choices": [[
+                    "index": 0,
+                    "message": [
+                        "role": "assistant",
+                        "content": NSNull(),
+                        "reasoning_content": "native Kimi thought",
+                        "tool_calls": [[
+                            "id": "call-1",
+                            "type": "function",
+                            "function": ["name": "lookup", "arguments": "{}"],
+                        ]],
+                    ],
+                    "finish_reason": "tool_calls",
+                ]],
+            ]
+            return try self.jsonResponse(for: urlRequest, data: JSONSerialization.data(withJSONObject: payload))
+        } operation: { session in
+            try await OpenAICompatibleHelper.generateText(
+                request: ProviderRequest(messages: [.user("hi")]),
+                modelId: "kimi-k2.7-code",
+                baseURL: "https://api.moonshot.cn/v1",
+                apiKey: "sk-test",
+                providerName: "Kimi",
+                session: session,
+            )
+        }
+
+        let reasoning = try #require(response.reasoning.first)
+        #expect(reasoning.type == "kimi_reasoning_content")
+        #expect(reasoning.text == "native Kimi thought")
+        #expect(response.toolCalls?.first?.id == "call-1")
+    }
+
+    @Test
+    func `generateText replays Kimi reasoning only for matching model and endpoint`() async throws {
+        let capture = CapturedRequest()
+        let call = AgentToolCall(id: "call-1", name: "lookup", arguments: [:])
+        let endpoint = "https://api.moonshot.cn/v1"
+        let request = try ProviderRequest(messages: [
+            .user("hi"),
+            ModelMessage(
+                role: .assistant,
+                content: [.text("native Kimi thought")],
+                channel: .thinking,
+                metadata: .init(customData: [
+                    "kimi.reasoning_content": "native Kimi thought",
+                    "tachikoma.reasoning.provider": "kimi",
+                    "tachikoma.reasoning.model": "kimi-k2.7-code",
+                    "tachikoma.reasoning.base_url": #require(ReasoningEndpointIdentity.canonical(endpoint)),
+                ]),
+            ),
+            ModelMessage(role: .assistant, content: [.toolCall(call)]),
+            ModelMessage(
+                role: .tool,
+                content: [.toolResult(.success(toolCallId: "call-1", result: AnyAgentToolValue(string: "ok")))],
+            ),
+        ])
+
+        _ = try await self.withMockedSession { urlRequest in
+            capture.body = self.bodyData(from: urlRequest)
+            return self.jsonResponse(for: urlRequest, data: Self.chatCompletionPayload(text: "done"))
+        } operation: { session in
+            try await OpenAICompatibleHelper.generateText(
+                request: request,
+                modelId: "kimi-k2.7-code",
+                baseURL: endpoint,
+                apiKey: "sk-test",
+                providerName: "Kimi",
+                session: session,
+            )
+        }
+
+        let bodyJSON = try #require(capture.body).jsonObject()
+        let messages = try #require(bodyJSON["messages"] as? [[String: Any]])
+        let assistant = try #require(messages.first { $0["role"] as? String == "assistant" })
+        #expect(assistant["reasoning_content"] as? String == "native Kimi thought")
+        #expect(assistant["tool_calls"] != nil)
     }
 
     @Test

--- a/Tests/TachikomaTests/Core/ProviderTests.swift
+++ b/Tests/TachikomaTests/Core/ProviderTests.swift
@@ -119,7 +119,7 @@ enum ProviderTests {
             #expect(Provider.google.defaultBaseURL == "https://generativelanguage.googleapis.com/v1beta")
             #expect(Provider.minimax.defaultBaseURL == "https://api.minimax.io/anthropic")
             #expect(Provider.minimaxCN.defaultBaseURL == "https://api.minimaxi.com/anthropic")
-            #expect(Provider.kimi.defaultBaseURL == "https://api.moonshot.cn/v1")
+            #expect(Provider.kimi.defaultBaseURL == "https://api.moonshot.ai/v1")
             #expect(Provider.ollama.defaultBaseURL == "http://localhost:11434")
             #expect(Provider.azureOpenAI.defaultBaseURL == nil)
             #expect(Provider.custom("test").defaultBaseURL == nil)

--- a/Tests/TachikomaTests/Core/ProviderTests.swift
+++ b/Tests/TachikomaTests/Core/ProviderTests.swift
@@ -52,6 +52,7 @@ enum ProviderTests {
             #expect(Provider.google.identifier == "google")
             #expect(Provider.minimax.identifier == "minimax")
             #expect(Provider.minimaxCN.identifier == "minimax-cn")
+            #expect(Provider.kimi.identifier == "kimi")
             #expect(Provider.ollama.identifier == "ollama")
             #expect(Provider.azureOpenAI.identifier == "azure-openai")
         }
@@ -72,6 +73,7 @@ enum ProviderTests {
             #expect(Provider.google.displayName == "Google")
             #expect(Provider.minimax.displayName == "MiniMax")
             #expect(Provider.minimaxCN.displayName == "MiniMax China")
+            #expect(Provider.kimi.displayName == "Kimi")
             #expect(Provider.ollama.displayName == "Ollama")
             #expect(Provider.azureOpenAI.displayName == "Azure OpenAI")
             #expect(Provider.custom("test").displayName == "Test")
@@ -87,6 +89,7 @@ enum ProviderTests {
             #expect(Provider.google.environmentVariable == "GEMINI_API_KEY")
             #expect(Provider.minimax.environmentVariable == "MINIMAX_API_KEY")
             #expect(Provider.minimaxCN.environmentVariable == "MINIMAX_CN_API_KEY")
+            #expect(Provider.kimi.environmentVariable == "MOONSHOT_API_KEY")
             #expect(Provider.ollama.environmentVariable == "OLLAMA_API_KEY")
             #expect(Provider.azureOpenAI.environmentVariable == "AZURE_OPENAI_API_KEY")
             #expect(Provider.custom("test").environmentVariable.isEmpty)
@@ -97,6 +100,7 @@ enum ProviderTests {
             #expect(Provider.grok.alternativeEnvironmentVariables == ["XAI_API_KEY", "GROK_API_KEY"])
             #expect(Provider.google.alternativeEnvironmentVariables == ["GOOGLE_API_KEY"])
             #expect(Provider.minimaxCN.alternativeEnvironmentVariables == ["MINIMAX_API_KEY"])
+            #expect(Provider.kimi.alternativeEnvironmentVariables == ["KIMI_API_KEY"])
             #expect(Provider.openai.alternativeEnvironmentVariables.isEmpty)
             #expect(Provider.anthropic.alternativeEnvironmentVariables.isEmpty)
             #expect(Provider.azureOpenAI.alternativeEnvironmentVariables == [
@@ -115,6 +119,7 @@ enum ProviderTests {
             #expect(Provider.google.defaultBaseURL == "https://generativelanguage.googleapis.com/v1beta")
             #expect(Provider.minimax.defaultBaseURL == "https://api.minimax.io/anthropic")
             #expect(Provider.minimaxCN.defaultBaseURL == "https://api.minimaxi.com/anthropic")
+            #expect(Provider.kimi.defaultBaseURL == "https://api.moonshot.cn/v1")
             #expect(Provider.ollama.defaultBaseURL == "http://localhost:11434")
             #expect(Provider.azureOpenAI.defaultBaseURL == nil)
             #expect(Provider.custom("test").defaultBaseURL == nil)
@@ -130,6 +135,7 @@ enum ProviderTests {
             #expect(Provider.google.requiresAPIKey == true)
             #expect(Provider.minimax.requiresAPIKey == true)
             #expect(Provider.minimaxCN.requiresAPIKey == true)
+            #expect(Provider.kimi.requiresAPIKey == true)
             #expect(Provider.ollama.requiresAPIKey == false) // Ollama typically doesn't require API key
             #expect(Provider.azureOpenAI.requiresAPIKey == true)
             #expect(Provider.custom("test").requiresAPIKey == true) // Assume custom providers need keys
@@ -148,6 +154,8 @@ enum ProviderTests {
             #expect(Provider.from(identifier: "minimax") == .minimax)
             #expect(Provider.from(identifier: "minimax-cn") == .minimaxCN)
             #expect(Provider.from(identifier: "minimaxi") == .minimaxCN)
+            #expect(Provider.from(identifier: "kimi") == .kimi)
+            #expect(Provider.from(identifier: "moonshot") == .kimi)
             #expect(Provider.from(identifier: "ollama") == .ollama)
             #expect(Provider.from(identifier: "azure-openai") == .azureOpenAI)
         }
@@ -188,6 +196,7 @@ enum ProviderTests {
                 .google,
                 .minimax,
                 .minimaxCN,
+                .kimi,
                 .ollama,
                 .azureOpenAI,
             ]

--- a/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
+++ b/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
@@ -523,7 +523,7 @@ struct ProviderEndToEndTests {
         let request = ProviderRequest(messages: [ModelMessage.user(text: "Inspect", images: [image])])
 
         try await NetworkMocking.withMockedNetwork { request in
-            #expect(request.url?.absoluteString == "https://api.moonshot.cn/v1/chat/completions")
+            #expect(request.url?.absoluteString == "https://api.moonshot.ai/v1/chat/completions")
             #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer live-kimi")
             let body = try #require(self.bodyData(from: request))
             let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
@@ -559,7 +559,7 @@ struct ProviderEndToEndTests {
                     data: #"{"error":{"message":"rate limited","type":"rate_limit_error"}}"#.utf8Data(),
                     statusCode: 429,
                 )
-            case "api.moonshot.cn":
+            case "api.moonshot.ai":
                 return NetworkMocking.jsonResponse(
                     for: request,
                     data: Self.chatCompletionPayload(text: "Kimi remained available"),

--- a/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
+++ b/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
@@ -673,20 +673,24 @@ struct ProviderEndToEndTests {
     private static func kimiPayload(text: String, reasoning: String) -> Data {
         let dict: [String: Any] = [
             "id": "chatcmpl-kimi",
-            "choices": [[
-                "index": 0,
-                "message": [
-                    "role": "assistant",
-                    "content": text,
-                    "reasoning_content": reasoning,
-                    "tool_calls": [[
-                        "id": "call-1",
-                        "type": "function",
-                        "function": ["name": "lookup", "arguments": "{}"],
-                    ]],
+            "choices": [
+                [
+                    "index": 0,
+                    "message": [
+                        "role": "assistant",
+                        "content": text,
+                        "reasoning_content": reasoning,
+                        "tool_calls": [
+                            [
+                                "id": "call-1",
+                                "type": "function",
+                                "function": ["name": "lookup", "arguments": "{}"],
+                            ],
+                        ],
+                    ],
+                    "finish_reason": "tool_calls",
                 ],
-                "finish_reason": "tool_calls",
-            ]],
+            ],
             "usage": ["prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15],
         ]
         return try! JSONSerialization.data(withJSONObject: dict)

--- a/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
+++ b/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
@@ -517,6 +517,72 @@ struct ProviderEndToEndTests {
         }
     }
 
+    @Test
+    func `Kimi provider uses official endpoint and preserves reasoning content`() async throws {
+        let image = ModelMessage.ContentPart.ImageContent(data: "aW1hZ2U=", mimeType: "image/png")
+        let request = ProviderRequest(messages: [ModelMessage.user(text: "Inspect", images: [image])])
+
+        try await NetworkMocking.withMockedNetwork { request in
+            #expect(request.url?.absoluteString == "https://api.moonshot.cn/v1/chat/completions")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer live-kimi")
+            let body = try #require(self.bodyData(from: request))
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            #expect(json["model"] as? String == "kimi-k2.7-code")
+            let messages = try #require(json["messages"] as? [[String: Any]])
+            let content = try #require(messages.first?["content"] as? [[String: Any]])
+            #expect(content.contains { $0["type"] as? String == "image_url" })
+            return NetworkMocking.jsonResponse(
+                for: request,
+                data: Self.kimiPayload(text: "", reasoning: "native Kimi thought"),
+            )
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setAPIKey("live-kimi", for: .kimi)
+            }
+            let provider = try KimiProvider(model: .k27Code, configuration: config)
+            let response = try await provider.generateText(request: request)
+            #expect(response.reasoning.first?.type == "kimi_reasoning_content")
+            #expect(response.reasoning.first?.text == "native Kimi thought")
+            #expect(response.toolCalls?.first?.name == "lookup")
+            #expect(provider.capabilities.contextLength == 262_144)
+            #expect(provider.capabilities.maxOutputTokens == 32768)
+        }
+    }
+
+    @Test
+    func `MiniMax rate limit does not contaminate Kimi routing`() async throws {
+        try await NetworkMocking.withMockedNetwork { request in
+            switch request.url?.host {
+            case "api.minimax.io":
+                return NetworkMocking.jsonResponse(
+                    for: request,
+                    data: #"{"error":{"message":"rate limited","type":"rate_limit_error"}}"#.utf8Data(),
+                    statusCode: 429,
+                )
+            case "api.moonshot.cn":
+                return NetworkMocking.jsonResponse(
+                    for: request,
+                    data: Self.chatCompletionPayload(text: "Kimi remained available"),
+                )
+            default:
+                throw TachikomaError.invalidConfiguration("Unexpected host")
+            }
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setAPIKey("live-minimax", for: .minimax)
+                config.setAPIKey("live-kimi", for: .kimi)
+            }
+            let miniMax = try ProviderFactory.createProvider(for: .minimax(.m27), configuration: config)
+            let kimi = try ProviderFactory.createProvider(for: .kimi(.k26), configuration: config)
+
+            await #expect(throws: TachikomaError.self) {
+                _ = try await miniMax.generateText(request: Self.basicRequest)
+            }
+            let response = try await kimi.generateText(request: Self.basicRequest)
+            #expect(response.text == "Kimi remained available")
+        }
+    }
+
     // MARK: - Helpers
 
     private func assertOpenAICompatibleProvider(_ model: LanguageModel, provider: Provider) async throws {
@@ -600,6 +666,28 @@ struct ProviderEndToEndTests {
                 "completion_tokens": 5,
                 "total_tokens": 15,
             ],
+        ]
+        return try! JSONSerialization.data(withJSONObject: dict)
+    }
+
+    private static func kimiPayload(text: String, reasoning: String) -> Data {
+        let dict: [String: Any] = [
+            "id": "chatcmpl-kimi",
+            "choices": [[
+                "index": 0,
+                "message": [
+                    "role": "assistant",
+                    "content": text,
+                    "reasoning_content": reasoning,
+                    "tool_calls": [[
+                        "id": "call-1",
+                        "type": "function",
+                        "function": ["name": "lookup", "arguments": "{}"],
+                    ]],
+                ],
+                "finish_reason": "tool_calls",
+            ]],
+            "usage": ["prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15],
         ]
         return try! JSONSerialization.data(withJSONObject: dict)
     }

--- a/Tests/TachikomaTests/TestHelpers/TestHelpers.swift
+++ b/Tests/TachikomaTests/TestHelpers/TestHelpers.swift
@@ -11,12 +11,6 @@ enum TestHelpers {
     )
         -> TachikomaConfiguration
     {
-        // For tests that rely on profile fixtures, keep a deterministic dir unless empty config
-        if apiKeys.isEmpty {
-            TachikomaConfiguration.profileDirectoryName = ".tachikoma-tests-\(UUID().uuidString)"
-        } else {
-            // leave profileDirectoryName as-is so registry tests can load fixtures
-        }
         let config = TachikomaConfiguration(loadFromEnvironment: false)
         for (provider, key) in apiKeys {
             config.setAPIKey(key, for: provider)
@@ -82,12 +76,16 @@ enum TestHelpers {
         -> T
     {
         try await TestEnvironmentMutex.shared.withLock {
+            let previousProfileDirectory = TachikomaConfiguration.profileDirectoryName
             let previousIgnore = TKAuthManager.shared.setIgnoreEnvironment(true)
             let previousIgnoreStore = TKAuthManager.shared.setIgnoreCredentialStore(true)
             defer {
+                TachikomaConfiguration.profileDirectoryName = previousProfileDirectory
                 TKAuthManager.shared.setIgnoreEnvironment(previousIgnore)
                 TKAuthManager.shared.setIgnoreCredentialStore(previousIgnoreStore)
             }
+
+            TachikomaConfiguration.profileDirectoryName = ".tachikoma-tests-\(UUID().uuidString)"
 
             let envKeys = [
                 "OPENAI_API_KEY",

--- a/Tests/TachikomaTests/Utilities/UsageTrackingTests.swift
+++ b/Tests/TachikomaTests/Utilities/UsageTrackingTests.swift
@@ -160,6 +160,14 @@ struct UsageTrackingTests {
         #expect(grok420Cost.output == 2.50)
         #expect(grok420Cost.total == 3.75)
 
+        let kimiCost = calculator.calculateCost(for: .kimi(.k26), usage: usage)
+        #expect(kimiCost.input == 0.95)
+        #expect(kimiCost.output == 4.00)
+
+        let kimiHighspeedCost = calculator.calculateCost(for: .kimi(.k27CodeHighspeed), usage: usage)
+        #expect(kimiHighspeedCost.input == 1.90)
+        #expect(kimiHighspeedCost.output == 8.00)
+
         // Test Ollama (should be free)
         let ollamaCost = calculator.calculateCost(for: .ollama(.llama33), usage: usage)
         #expect(ollamaCost.input == 0.0)

--- a/docs/models.md
+++ b/docs/models.md
@@ -39,6 +39,16 @@ Notes:
 - `MiniMax-M2.7`
 - `MiniMax-M2.7-highspeed`
 
+## Kimi / Moonshot AI (`LanguageModel.Kimi`)
+
+- `kimi-k2.6`
+- `kimi-k2.7-code`
+- `kimi-k2.7-code-highspeed`
+
+Kimi uses Moonshot's OpenAI-compatible endpoint at `https://api.moonshot.cn/v1`. Configure
+`MOONSHOT_API_KEY` (or `KIMI_API_KEY`); override the endpoint with `MOONSHOT_BASE_URL`. K2.7 tool-call
+turns preserve Moonshot's provider-native `reasoning_content` when replaying assistant history.
+
 ## xAI Grok (`LanguageModel.Grok`)
 
 - `grok-4.3`

--- a/docs/models.md
+++ b/docs/models.md
@@ -45,7 +45,7 @@ Notes:
 - `kimi-k2.7-code`
 - `kimi-k2.7-code-highspeed`
 
-Kimi uses Moonshot's OpenAI-compatible endpoint at `https://api.moonshot.cn/v1`. Configure
+Kimi uses Moonshot's OpenAI-compatible endpoint at `https://api.moonshot.ai/v1`. Configure
 `MOONSHOT_API_KEY` (or `KIMI_API_KEY`); override the endpoint with `MOONSHOT_BASE_URL`. K2.7 tool-call
 turns preserve Moonshot's provider-native `reasoning_content` when replaying assistant history.
 


### PR DESCRIPTION
## Summary

Adds Kimi (Moonshot AI) as a first-class OpenAI-compatible provider using the official public API contract:

- `kimi-k2.6`
- `kimi-k2.7-code`
- `kimi-k2.7-code-highspeed`
- `https://api.moonshot.ai/v1`

All three models expose 256K context, image input, tool calling, streaming, and the documented 32K output limit. Kimi reasoning is decoded, streamed, and replayed as provider-native `reasoning_content`, bound to the exact model and canonical endpoint so it cannot leak into unrelated providers or routes. K2.6 replay conditionally enables Moonshot's preserved-thinking request option; K2.7 behavior remains unchanged.

## Changes

- Added the Kimi model catalog, provider configuration, parser/selector aliases, provider factory routing, CLI setup guidance, capabilities, and usage estimates.
- Added a dedicated `KimiProvider` instead of widening the generic compatible-provider API.
- Replaced the proposed unofficial model IDs and coding endpoint with Moonshot's current documented IDs and global public endpoint.
- Added exact request/response tests for auth, endpoint, model, image payloads, tools, non-streaming reasoning, streaming reasoning, and reasoning replay.
- Added a regression proving a MiniMax HTTP 429 does not contaminate a subsequent Kimi route.
- Updated usage pricing to Moonshot's current published global rates.
- Enabled documented `thinking.keep = "all"` only when replaying K2.6 historical reasoning, with regression coverage.
- Added docs and an Unreleased changelog entry thanking @Tugser.
- Fixed a shared-profile test race exposed by the full parallel suite.

## Primary contracts

- [Kimi K2.6 quickstart](https://platform.kimi.ai/docs/guide/kimi-k2-6-quickstart)
- [Kimi K2.7 Code quickstart](https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart)
- [Kimi thinking and preserved-reasoning guide](https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model)
- [Kimi API setup](https://platform.kimi.ai/docs/guide/start-using-kimi-api)
- [Kimi K2.6 pricing](https://platform.kimi.ai/docs/pricing/chat-k26)
- [Kimi K2.7 Code pricing](https://platform.kimi.ai/docs/pricing/chat-k27-code)

## Exact-head proof

Head: `7489bc48474163e6b5af2c4bf14c18a4c104c5cb`

- `swiftformat --lint .` — clean
- `swiftlint lint --config .swiftlint.yml --strict --quiet` — clean
- `TACHIKOMA_TEST_MODE=mock swift test --no-parallel` — 773 tests in 103 suites passed after integrating current `main`
- Focused helper/provider suites — K2.6 preserved-reasoning request shape, Kimi request/vision encoding, and MiniMax 429 followed by successful Kimi routing passed
- `$autoreview` — clean after repairing its K2.6 preserved-thinking finding; final integrated full-branch verdict clean with no accepted/actionable findings (0.77 confidence)
- Public model identifier gate — PASS for all three model IDs and the global endpoint against Moonshot's official docs
- Exact-head CI — [CI](https://github.com/openclaw/Tachikoma/actions/runs/28508418270), [Tests](https://github.com/openclaw/Tachikoma/actions/runs/28508418371), [Cross-Platform CI](https://github.com/openclaw/Tachikoma/actions/runs/28508418322), and [Lint](https://github.com/openclaw/Tachikoma/actions/runs/28508418350) all passed
- Authenticated K2.6 two-turn text call through Tachikoma — provider-native reasoning returned, replay accepted with preserved thinking, exact token `KIMI_PRESERVED_OK`
- Authenticated K2.6 vision call through Tachikoma — approved public `docs/assets/readme-banner.jpg` uploaded to Moonshot's Kimi API and read successfully, exact token `KIMI_VISION_OK`

```text
result=PASS provider=kimi model=kimi-k2.6 mode=text preserved_reasoning=true token=KIMI_PRESERVED_OK
result=PASS provider=kimi model=kimi-k2.6 mode=vision asset=readme-banner.jpg token=KIMI_VISION_OK
```
