### PR TITLE
[codex] report only tested release platforms

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -90,15 +90,13 @@ jobs:
       
       - name: Create release info
         run: |
-          echo "✅ All platforms tested successfully" >> release-info.txt
+          echo "✅ Linux validation completed successfully" >> release-info.txt
           echo "" >> release-info.txt
           echo "Tested Platforms:" >> release-info.txt
-          echo "• macOS 14 (Sonoma) ✅" >> release-info.txt
-          echo "• macOS 15 (Sequoia) ✅" >> release-info.txt
           echo "• Ubuntu 22.04 LTS ✅" >> release-info.txt
           echo "• Ubuntu 24.04 LTS ✅" >> release-info.txt
           echo "" >> release-info.txt
-          echo "Total: 4 platform configurations tested in parallel" >> release-info.txt
+          echo "Total: 2 Linux configurations tested in parallel" >> release-info.txt
       
       - name: Upload release info
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## What changed

- make the cross-platform release proof artifact list only Ubuntu 22.04 and 24.04
- change the summary from four platforms to the two Linux configurations that actually gate the artifact

## Why

The macOS 14 and macOS 15 jobs are currently disabled with `if: false`, but the generated artifact still claimed both passed. This keeps published validation evidence aligned with executed jobs.

## Validation

- `git diff --check`
- parsed `.github/workflows/cross-platform.yml` with Ruby YAML
